### PR TITLE
GW-1418: Move ECI field to root of PaymentResponse

### DIFF
--- a/src/CheckoutSdk/Payments/GetPaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/GetPaymentResponse.cs
@@ -98,6 +98,11 @@ namespace Checkout.Payments
         public Dictionary<string, object> Metadata { get; set; }
 
         /// <summary>
+        /// The final Electronic Commerce Indicator security level used to authorize the payment. Applicable for 3D-Secure, digital wallets and network token payments.
+        /// </summary>
+        public string Eci { get; set; }
+
+        /// <summary>
         /// Determines whether the payment requires a redirect.
         /// </summary>
         /// <returns>True if a redirect is required, otherwise False.</returns>

--- a/src/CheckoutSdk/Payments/PaymentProcessed.cs
+++ b/src/CheckoutSdk/Payments/PaymentProcessed.cs
@@ -88,6 +88,11 @@ namespace Checkout.Payments
         public string Reference { get; set; }
 
         /// <summary>
+        /// The final Electronic Commerce Indicator security level used to authorize the payment. Applicable for 3D-Secure, digital wallets and network token payments.
+        /// </summary>
+        public string Eci { get; set; }
+
+        /// <summary>
         /// Gets the payment's actions link.
         /// </summary>
         /// <returns>The link if present, otherwise null.</returns>

--- a/src/CheckoutSdk/Payments/ThreeDsEnrollment.cs
+++ b/src/CheckoutSdk/Payments/ThreeDsEnrollment.cs
@@ -31,12 +31,7 @@ namespace Checkout.Payments
         /// U - Unable to perform authentication
         /// </summary>
         public string AuthenticationResponse { get; set; }
-        
-        /// <summary>
-        /// Gets the E-Commerce Indicator security level associated with the payment.
-        /// </summary>
-        public string Eci { get; set; }
-        
+               
         /// <summary>
         /// Gets the cryptographic identifier used by the card schemes to validate the integrity of the 3D secure payment data.
         /// </summary>


### PR DESCRIPTION
[GW-1418](https://checkout.atlassian.net/browse/GW-1418)

We can add related tests when network token payment / support for 3rd party MPI goes live.