### PR TITLE
GW-1424: Split Customer into Request and Response

### DIFF
--- a/src/CheckoutSdk/Payments/CustomerRequest.cs
+++ b/src/CheckoutSdk/Payments/CustomerRequest.cs
@@ -1,9 +1,9 @@
 ﻿namespace Checkout.Payments
 {
     /// <summary>
-    /// Represents a customer in a payment request or response.
+    /// Represents a customer in a payment request.
     /// </summary>
-    public class Customer
+    public class CustomerRequest
     {
         /// <summary>
         /// Gets or sets the unique identifier of the customer. This can be specified in a <see cref="CustomerSource"/> 

--- a/src/CheckoutSdk/Payments/CustomerResponse.cs
+++ b/src/CheckoutSdk/Payments/CustomerResponse.cs
@@ -1,0 +1,29 @@
+﻿namespace Checkout.Payments
+{
+    /// <summary>
+    /// Represents a customer in a payment response.
+    /// </summary>
+    public class CustomerResponse
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier of the customer. This can be specified in a <see cref="CustomerSource"/> 
+        /// in subsequent payment requests to use the customer's default payment method.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the customer email address.
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets the customer full name.
+        /// </summary>
+        public string Name { get; set; }
+
+        public CustomerRequest ToRequest()
+        {
+            return new CustomerRequest() { Id = Id, Email = Email, Name = Name };
+        }
+    }
+}

--- a/src/CheckoutSdk/Payments/CustomerResponse.cs
+++ b/src/CheckoutSdk/Payments/CustomerResponse.cs
@@ -20,10 +20,5 @@
         /// Gets or sets the customer full name.
         /// </summary>
         public string Name { get; set; }
-
-        public CustomerRequest ToRequest()
-        {
-            return new CustomerRequest() { Id = Id, Email = Email, Name = Name };
-        }
     }
 }

--- a/src/CheckoutSdk/Payments/GetPaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/GetPaymentResponse.cs
@@ -70,7 +70,7 @@ namespace Checkout.Payments
         /// <summary>
         /// Gest the customer to which this payment is linked.
         /// </summary>
-        public Customer Customer { get; set; }
+        public CustomerResponse Customer { get; set; }
         
         /// <summary>
         /// Gets the billing descriptor displayed on the account owner's statement.

--- a/src/CheckoutSdk/Payments/PaymentPending.cs
+++ b/src/CheckoutSdk/Payments/PaymentPending.cs
@@ -26,7 +26,7 @@ namespace Checkout.Payments
         /// <summary>
         /// Gets the customer to which this payment is linked.
         /// </summary>
-        public Customer Customer { get; set; }
+        public CustomerResponse Customer { get; set; }
         
         /// <summary>
         /// Gets the 3D-Secure enrollment status.

--- a/src/CheckoutSdk/Payments/PaymentProcessed.cs
+++ b/src/CheckoutSdk/Payments/PaymentProcessed.cs
@@ -75,7 +75,7 @@ namespace Checkout.Payments
         /// <summary>
         /// Gets the customer to which this payment is linked.
         /// </summary>
-        public Customer Customer { get; set; }
+        public CustomerResponse Customer { get; set; }
         
         /// <summary>
         /// Gets the date/time the payment was processed.

--- a/src/CheckoutSdk/Payments/PaymentRequest.cs
+++ b/src/CheckoutSdk/Payments/PaymentRequest.cs
@@ -77,7 +77,7 @@ namespace Checkout.Payments
         /// <summary>
         /// Gets or sets details of the customer associated with the payment.
         /// </summary>
-        public Customer Customer { get; set; }
+        public CustomerRequest Customer { get; set; }
 
         /// <summary>
         /// Gets or sets an optional dynamic billing descriptor displayed on the account owner's statement.

--- a/test/CheckoutSdk.Tests/Payments/IdSourcePaymentsTests.cs
+++ b/test/CheckoutSdk.Tests/Payments/IdSourcePaymentsTests.cs
@@ -30,7 +30,7 @@ namespace Checkout.Tests.Payments
             )
             {
                 Capture = false,
-                Customer = firstCardPaymentResponse.Payment.Customer.ToRequest()
+                Customer = ToRequest(firstCardPaymentResponse.Payment.Customer)
             };
 
             PaymentResponse apiResponseForCustomerSourcePayment = await _api.Payments.RequestAsync(cardIdPaymentRequest);
@@ -50,6 +50,11 @@ namespace Checkout.Tests.Payments
             apiResponseForCustomerSourcePayment.Payment.Source.AsCard().Id.ShouldBe(firstCardPaymentResponse.Payment?.Source?.AsCard().Id);
             apiResponseForCustomerSourcePayment.Payment.CanCapture().ShouldBeTrue();
             apiResponseForCustomerSourcePayment.Payment.CanVoid().ShouldBeTrue();
+        }
+
+        private CustomerRequest ToRequest(CustomerResponse customer)
+        {
+            return new CustomerRequest() { Id = customer.Id, Email = customer.Email, Name = customer.Name };
         }
     }
 }

--- a/test/CheckoutSdk.Tests/Payments/IdSourcePaymentsTests.cs
+++ b/test/CheckoutSdk.Tests/Payments/IdSourcePaymentsTests.cs
@@ -30,7 +30,7 @@ namespace Checkout.Tests.Payments
             )
             {
                 Capture = false,
-                Customer = firstCardPaymentResponse.Payment.Customer
+                Customer = firstCardPaymentResponse.Payment.Customer.ToRequest()
             };
 
             PaymentResponse apiResponseForCustomerSourcePayment = await _api.Payments.RequestAsync(cardIdPaymentRequest);

--- a/test/CheckoutSdk.Tests/TestHelper.cs
+++ b/test/CheckoutSdk.Tests/TestHelper.cs
@@ -19,7 +19,7 @@ namespace Checkout.Tests
             )
             {
                 Capture = false,
-                Customer = new Customer() { Email = TestHelper.GenerateRandomEmail()},
+                Customer = new CustomerRequest() { Email = TestHelper.GenerateRandomEmail()},
                 Reference = Guid.NewGuid().ToString()
             };
         }


### PR DESCRIPTION
I know at this moment the only occurrence of CustomerResponse.ToRequest() is within the tests which is usually not a good enough reason to have it, but I think that might be a real-life scenario for devs using our SDK so decided to leave it there. 