### PR TITLE
GW-1632: Actions summary for 3D-Secure flow

### DIFF
--- a/samples/CheckoutSdk.SampleApp.Tests/CheckoutSdk.SampleApp.Tests.csproj
+++ b/samples/CheckoutSdk.SampleApp.Tests/CheckoutSdk.SampleApp.Tests.csproj
@@ -5,14 +5,13 @@
     <RootNamespace>Checkout.SampleApp.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0"/>
-    <PackageReference Include="Moq" Version="4.10.0"/>
-    <PackageReference Include="Shouldly" Version="3.0.1"/>
-    <PackageReference Include="xunit" Version="2.3.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1"/>
-    <PackageReference Include="CheckoutSDK.Extensions.Microsoft" Version="0.2.3"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Shouldly" Version="3.0.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CheckoutSdk.SampleApp\CheckoutSdk.SampleApp.csproj"/>
+    <ProjectReference Include="..\CheckoutSdk.SampleApp\CheckoutSdk.SampleApp.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/CheckoutSdk.SampleApp/CheckoutSdk.SampleApp.csproj
+++ b/samples/CheckoutSdk.SampleApp/CheckoutSdk.SampleApp.csproj
@@ -6,9 +6,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6"/>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.6"/>
-    <PackageReference Include="CheckoutSDK.Extensions.Microsoft" Version="0.2.3"/>
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0"/>
+  </ItemGroup>
+  <ItemGroup>
+      <ProjectReference Include="..\..\src\CheckoutSDK.Extensions.Microsoft\CheckoutSDK.Extensions.Microsoft.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/CheckoutSdk.SampleApp/Views/Payments/ThreeDSFailure.cshtml
+++ b/samples/CheckoutSdk.SampleApp/Views/Payments/ThreeDSFailure.cshtml
@@ -32,6 +32,14 @@
         <td>Card Source Id</td>
         <td>@Html.DisplayFor(model => model.Source.AsCard().Id)</td>
     </tr>
+    <tr>
+        <td>Response Code</td>
+        <td>@Html.DisplayFor(model => model.GetAuthorizationAction().ResponseCode)</td>
+    </tr>
+    <tr>
+        <td>Response Summary</td>
+        <td>@Html.DisplayFor(model => model.GetAuthorizationAction().ResponseSummary)</td>
+    </tr>
 </table>
 <div>
     <a asp-action="Index">New payment</a>

--- a/samples/CheckoutSdk.SampleApp/Views/Payments/ThreeDSSuccess.cshtml
+++ b/samples/CheckoutSdk.SampleApp/Views/Payments/ThreeDSSuccess.cshtml
@@ -32,6 +32,14 @@
         <td>Card Source Id</td>
         <td>@Html.DisplayFor(model => model.Source.AsCard().Id)</td>
     </tr>
+    <tr>
+        <td>Response Code</td>
+        <td>@Html.DisplayFor(model => model.GetAuthorizationAction().ResponseCode)</td>
+    </tr>
+    <tr>
+        <td>Response Summary</td>
+        <td>@Html.DisplayFor(model => model.GetAuthorizationAction().ResponseSummary)</td>
+    </tr>
 </table>
 
 <div>

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,7 @@ First update `appsettings.json` to include your Checkout.com API keys or add an 
   }
 ```
 
-Install CSS/JS dependencies using Bower (should be done automatically is using Visual Studio 2017):
+Install CSS/JS dependencies using Bower (should be done automatically if using Visual Studio 2017):
 
 ```
 bower install

--- a/src/CheckoutSdk/Payments/GetPaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/GetPaymentResponse.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Checkout.Common;
 using Newtonsoft.Json;
 
@@ -40,7 +41,7 @@ namespace Checkout.Payments
         /// Gets the payment type.
         /// </summary>
         public string PaymentType { get; set; }
-        
+
         /// <summary>
         /// Gets your reference for the payment.
         /// </summary>
@@ -108,6 +109,11 @@ namespace Checkout.Payments
         public string Eci { get; set; }
 
         /// <summary>
+        /// A summary of the payment's actions, returned when a session ID is used to get the payment details
+        /// </summary>
+        public IEnumerable<PaymentActionSummary> Actions { get; set; }
+
+        /// <summary>
         /// Determines whether the payment requires a redirect.
         /// </summary>
         /// <returns>True if a redirect is required, otherwise False.</returns>
@@ -118,5 +124,13 @@ namespace Checkout.Payments
         /// </summary>
         /// <returns>The link if present, otherwise null.</returns>
         public Link GetRedirectLink() => GetLink("redirect");
+
+        /// <summary>
+        /// Gets the payment's authorization action, returned when a session ID is used to get the payment details.
+        /// This can be used to obtain the decline reason in the case of a 3DS decline.
+        /// </summary>
+        /// <returns></returns>
+        public PaymentActionSummary GetAuthorizationAction() 
+            => Actions?.FirstOrDefault(act => ActionType.Authorization.Equals(act.Type, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/CheckoutSdk/Payments/PaymentActionSummary.cs
+++ b/src/CheckoutSdk/Payments/PaymentActionSummary.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace Checkout.Payments
 {
     /// <summary>
-    /// Defines a payment action.
+    /// Summary of a payment action.
     /// </summary>
     public class PaymentActionSummary
     {

--- a/src/CheckoutSdk/Payments/PaymentActionSummary.cs
+++ b/src/CheckoutSdk/Payments/PaymentActionSummary.cs
@@ -1,0 +1,32 @@
+using Checkout.Common;
+using System;
+using System.Collections.Generic;
+
+namespace Checkout.Payments
+{
+    /// <summary>
+    /// Defines a payment action.
+    /// </summary>
+    public class PaymentActionSummary
+    {
+        /// <summary>
+        /// Gets the unique identifier of the payment action.
+        /// </summary>
+        public string Id { get; set; }
+        
+        /// <summary>
+        /// Gets the type of action.
+        /// </summary>
+        public string Type { get; set; }
+        
+        /// <summary>
+        /// Gets the Checkout.com Gateway response code.
+        /// </summary>
+        public string ResponseCode { get; set; }
+        
+        /// <summary>
+        /// Gets the response summary.
+        /// </summary>
+        public string ResponseSummary { get; set; }
+    }
+}


### PR DESCRIPTION
This PR adds support for embedded actions, now returned when retrieving a payment using a 3D-Secure session ID as per the [api reference](https://api-reference.checkout.com).

The main use case is to obtain the response code/summary for a declined authorization since this is action level information and was not previously returned in the payment response.

A `GetAuthorizationAction` helper method provides easy access to the authorization details. The sample app has also been updated to illustrate this.