### PR TITLE
GW-1660: Fix alternative payment source type

### DIFF
--- a/src/CheckoutSdk/Payments/AlternativePaymentSource.cs
+++ b/src/CheckoutSdk/Payments/AlternativePaymentSource.cs
@@ -5,7 +5,7 @@ namespace Checkout.Payments
     /// <summary>
     /// Represents an Alternative Payment source for a payment request.
     /// </summary>
-    public class AlternativePaymentSource : Dictionary<string, string>, IRequestSource
+    public class AlternativePaymentSource : Dictionary<string, object>, IRequestSource
     {
         private const string TypeField = "type";
 

--- a/src/CheckoutSdk/Payments/AlternativePaymentSource.cs
+++ b/src/CheckoutSdk/Payments/AlternativePaymentSource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Checkout.Payments
@@ -12,14 +13,19 @@ namespace Checkout.Payments
         /// <summary>
         /// Creates a new <see cref="AlternativePaymentSource"/> instance.
         /// </summary>
-        public AlternativePaymentSource(string type) {
+        public AlternativePaymentSource(string type)
+        {
+            if (string.IsNullOrWhiteSpace(type))
+                throw new ArgumentException("The alternative payment source type is required.", nameof(type));
+
             Type = type;
         }
 
         /// <summary>
         /// Gets or sets the type of source.
         /// </summary>
-        public string Type {
+        public string Type
+        {
             get { return this[TypeField].ToString(); }
             set { this[TypeField] = value; }
         }

--- a/src/CheckoutSdk/Payments/AlternativePaymentSourceResponse.cs
+++ b/src/CheckoutSdk/Payments/AlternativePaymentSourceResponse.cs
@@ -5,8 +5,8 @@ namespace Checkout.Payments
     /// <summary>
     /// The alternative payment used to complete a payment request. 
     /// </summary>
-    public class AlternativePaymentSourceResponse : Dictionary<string, string>, IResponseSource
-    {        
+    public class AlternativePaymentSourceResponse : Dictionary<string, object>, IResponseSource
+    {
         /// <summary>
         /// Gets or sets the type of source.
         /// </summary>

--- a/test/CheckoutSdk.Tests/Payments/AlternativePaymentSourcePaymentsTests.cs
+++ b/test/CheckoutSdk.Tests/Payments/AlternativePaymentSourcePaymentsTests.cs
@@ -59,7 +59,7 @@ namespace Checkout.Tests.Payments
 
             foreach (string key in verifiedPayment.Source.AsAlternativePayment().Keys)
             {
-                (verifiedPayment.Source as Dictionary<string, string>)[key].ShouldBe((alternativePaymentSource as Dictionary<string, string>)[key]);
+                (verifiedPayment.Source as AlternativePaymentSourceResponse)[key].ShouldBe((alternativePaymentSource as AlternativePaymentSource)[key]);
             }
         }
 

--- a/test/CheckoutSdk.Tests/Payments/AlternativePaymentSourcePaymentsTests.cs
+++ b/test/CheckoutSdk.Tests/Payments/AlternativePaymentSourcePaymentsTests.cs
@@ -57,9 +57,10 @@ namespace Checkout.Tests.Payments
             verifiedPayment.ShouldNotBeNull();
             verifiedPayment.Id.ShouldBe(payment.Id);
 
-            foreach (string key in verifiedPayment.Source.AsAlternativePayment().Keys)
+            var verifiedSource = verifiedPayment.Source.AsAlternativePayment();
+            foreach (string key in verifiedSource.Keys)
             {
-                (verifiedPayment.Source as AlternativePaymentSourceResponse)[key].ShouldBe((alternativePaymentSource as AlternativePaymentSource)[key]);
+               verifiedSource[key].ShouldBe(alternativePaymentSource[key]);
             }
         }
 


### PR DESCRIPTION
[GW-1660](https://checkout.atlassian.net/browse/GW-1660)
`AlternativePaymentSource` and `AlternativePaymentResponseSource` now extends `Dictionary<string, object>` instead of `Dictionary<string, string>` to support complex request/response objects.