### PR TITLE
disposes response stream to close connection

### DIFF
--- a/src/CheckoutSdk/ApiClient.cs
+++ b/src/CheckoutSdk/ApiClient.cs
@@ -77,7 +77,10 @@ namespace Checkout
             if (credentials == null) throw new ArgumentNullException(nameof(credentials));
 
             using(var httpResponse = await SendRequestAsync(HttpMethod.Get, path, credentials, null, cancellationToken))
+            {
                 return await DeserializeJsonAsync<TResult>(httpResponse);
+            }
+                
         }
 
         public async Task<TResult> PostAsync<TResult>(string path, IApiCredentials credentials, CancellationToken cancellationToken, object request = null)
@@ -86,7 +89,9 @@ namespace Checkout
             if (credentials == null) throw new ArgumentNullException(nameof(credentials));
 
             using(var httpResponse = await SendRequestAsync(HttpMethod.Post, path, credentials, request, cancellationToken))
+            {
                 return await DeserializeJsonAsync<TResult>(httpResponse);
+            }                
         }
 
         public async Task<dynamic> PostAsync(string path, IApiCredentials credentials, Dictionary<HttpStatusCode, Type> resultTypeMappings, CancellationToken cancellationToken,  object request = null)


### PR DESCRIPTION
using .net core 2.1 or 2.2 on linux, connections are stack on CLOSE_WAIT state. please note that we do not use your DI singleton registration since we have multiple Merchant accounts and configurations loaded dynamically. 
find out more @ dotnet/corefx#37044