### PR TITLE
Added MS HttpClientFactory

### DIFF
--- a/samples/CheckoutSdk.SampleApp.Tests/CheckoutSdk.SampleApp.Tests.csproj
+++ b/samples/CheckoutSdk.SampleApp.Tests/CheckoutSdk.SampleApp.Tests.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Checkout.SampleApp.Tests</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.1" />

--- a/samples/CheckoutSdk.SampleApp/CheckoutSdk.SampleApp.csproj
+++ b/samples/CheckoutSdk.SampleApp/CheckoutSdk.SampleApp.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <RootNamespace>Checkout.SampleApp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6"/>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.6"/>
+    <PackageReference Include="Microsoft.AspNetCore.App"/>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2"/>
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0"/>
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0"/>
   </ItemGroup>
   <ItemGroup>
-      <ProjectReference Include="..\..\src\CheckoutSDK.Extensions.Microsoft\CheckoutSDK.Extensions.Microsoft.csproj" />
+    <ProjectReference Include="..\..\src\CheckoutSDK\CheckoutSDK.csproj"/>
+    <ProjectReference Include="..\..\src\CheckoutSDK.Extensions.Microsoft\CheckoutSDK.Extensions.Microsoft.csproj"/>
   </ItemGroup>
 </Project>

--- a/samples/CheckoutSdk.SampleApp/Controllers/PaymentsController.cs
+++ b/samples/CheckoutSdk.SampleApp/Controllers/PaymentsController.cs
@@ -1,7 +1,6 @@
 ﻿using Checkout.Common;
 using Checkout.Payments;
 using Checkout.SampleApp.Models;
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System;

--- a/samples/CheckoutSdk.SampleApp/CustomCkoHttpClientFactory.cs
+++ b/samples/CheckoutSdk.SampleApp/CustomCkoHttpClientFactory.cs
@@ -1,0 +1,19 @@
+using System.Net.Http;
+
+namespace Checkout.SampleApp
+{
+    public class CustomCkoHttpClientFactory : IHttpClientFactory
+    {
+        private readonly System.Net.Http.IHttpClientFactory _msHttpClientFactory;
+
+        public CustomCkoHttpClientFactory(System.Net.Http.IHttpClientFactory msHttpClientFactory)
+        {
+            _msHttpClientFactory = msHttpClientFactory;
+        }
+        
+        public HttpClient CreateClient()
+        {
+            return _msHttpClientFactory.CreateClient();
+        }
+    }
+}

--- a/samples/CheckoutSdk.SampleApp/Startup.cs
+++ b/samples/CheckoutSdk.SampleApp/Startup.cs
@@ -17,8 +17,9 @@ namespace Checkout.SampleApp
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
-
             services.AddCheckoutSdk(Configuration);
+            services.AddHttpClient();
+            services.AddTransient<IHttpClientFactory, CustomCkoHttpClientFactory>();
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)


### PR DESCRIPTION
This PR updates the sample app to demonstrate how to use MS' `HttpClientFactory` in .NET Core applications (2.1>).

I also took the opportunity to upgrade the application to ASP.NET Core 2.2.

Reference: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests