### PR TITLE
Allow handling of contentless API responses

### DIFF
--- a/src/CheckoutSdk/ApiClient.cs
+++ b/src/CheckoutSdk/ApiClient.cs
@@ -213,7 +213,37 @@ namespace Checkout
                 return null;
 
             var json = await httpResponse.Content.ReadAsStringAsync();
-            return _serializer.Deserialize(json, resultType);
+            if(!string.IsNullOrWhiteSpace(json))
+                return _serializer.Deserialize(json, resultType);
+            switch(httpResponse.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    return new CheckoutOkApiResponse(httpResponse.Headers);
+                case HttpStatusCode.Accepted:
+                    return new CheckoutAcceptedApiResponse(httpResponse.Headers);
+                case HttpStatusCode.NoContent:
+                    return new CheckoutNoContentApiResponse(httpResponse.Headers);
+                case HttpStatusCode.BadRequest:
+                    return new CheckoutBadRequestApiResponse(httpResponse.Headers);
+                case HttpStatusCode.Unauthorized:
+                    return new CheckoutUnauthorizedApiResponse(httpResponse.Headers);
+                case HttpStatusCode.Forbidden:
+                    return new CheckoutForbiddenApiResponse(httpResponse.Headers);
+                case HttpStatusCode.NotFound:
+                    return new CheckoutNotFoundApiResponse(httpResponse.Headers);                
+                case HttpStatusCode.Conflict:
+                    return new CheckoutConflictApiResponse(httpResponse.Headers);
+                case (HttpStatusCode)422:
+                    return new CheckoutUnprocessableEntityApiResponse(httpResponse.Headers);
+                case (HttpStatusCode)429:
+                    return new CheckoutTooManyRequestsApiResponse(httpResponse.Headers);
+                case HttpStatusCode.InternalServerError:
+                    return new CheckoutInternalServerErrorApiResponse(httpResponse.Headers);
+                case HttpStatusCode.BadGateway:
+                    return new CheckoutBadGatewayApiResponse(httpResponse.Headers);
+                default:
+                    throw new NotImplementedException($"Handling a contentless API response with status code {httpResponse.StatusCode} is not implemented.");
+            }
         }
 
         private async Task<HttpResponseMessage> SendRequestAsync(HttpMethod httpMethod, string path, IApiCredentials credentials, HttpContent httpContent, CancellationToken cancellationToken, string idempotencyKey)

--- a/src/CheckoutSdk/ApiClient.cs
+++ b/src/CheckoutSdk/ApiClient.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Checkout.Common;
+using System.Reflection;
 
 namespace Checkout
 {
@@ -248,13 +249,17 @@ namespace Checkout
 
         private async Task<HttpResponseMessage> SendRequestAsync(HttpMethod httpMethod, string path, IApiCredentials credentials, HttpContent httpContent, CancellationToken cancellationToken, string idempotencyKey)
         {
+            const string product = "checkout-sdk-net";
+            var productVersion = "undefined" ?? ReflectionUtils.GetAssemblyVersion<ApiClient>();
+
             if (string.IsNullOrEmpty(path)) throw new ArgumentNullException(nameof(path));
 
             var httpRequest = new HttpRequestMessage(httpMethod, GetRequestUri(path))
             {
                 Content = httpContent
             };
-            httpRequest.Headers.UserAgent.ParseAdd("checkout-sdk-net/" + ReflectionUtils.GetAssemblyVersion<ApiClient>());
+
+            httpRequest.Headers.UserAgent.ParseAdd($"{product}/{productVersion}");
             if(!string.IsNullOrWhiteSpace(idempotencyKey)) httpRequest.Headers.Add("Cko-Idempotency-Key", idempotencyKey);
 
             await credentials.AuthorizeAsync(httpRequest);

--- a/src/CheckoutSdk/CheckoutAcceptedApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutAcceptedApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 202 (Accepted) response.
+    /// </summary>
+    public class CheckoutAcceptedApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutAcceptedApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutAcceptedApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.Accepted, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutApiHttpResponseMessage.cs
+++ b/src/CheckoutSdk/CheckoutApiHttpResponseMessage.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// ApiHttpResponseMessage type for HTTP responses resulting from API operations.
+    /// </summary>
+    public class CheckoutApiHttpResponseMessage : CheckoutHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutApiHttpResponseMessage"/> instance.
+        /// </summary>
+        /// <param name="httpStatusCode">The HTTP status code of the API response.</param>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutApiHttpResponseMessage(HttpStatusCode httpStatusCode, HttpResponseHeaders httpResponseHeaders = null) 
+            : base(httpStatusCode)
+        {
+            HttpStatusCode = httpStatusCode;
+            if(httpResponseHeaders != null)
+            {
+                foreach (var httpResponseHeader in httpResponseHeaders)
+                {
+                    Headers.Add(httpResponseHeader.Key, httpResponseHeader.Value);
+                };
+            }
+        }
+
+        /// <summary>
+        /// Gets the HTTP status code of the API response.
+        /// </summary>
+        /// <value></value>
+        public HttpStatusCode HttpStatusCode { get; }
+        
+        /// <summary>
+        /// Gets the unique identifier of the API request.
+        /// </summary>
+        public string RequestId { get; }
+    }
+}

--- a/src/CheckoutSdk/CheckoutBadGatewayApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutBadGatewayApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 502 (Bad Gateway) response.
+    /// </summary>
+    public class CheckoutBadGatewayApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutBadGatewayApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutBadGatewayApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.BadGateway, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutBadRequestApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutBadRequestApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 400 (Bad Request) response.
+    /// </summary>
+    public class CheckoutBadRequestApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutBadRequestApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutBadRequestApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.BadRequest, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutConflictApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutConflictApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 409 (Conflict) response.
+    /// </summary>
+    public class CheckoutConflictApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutConflictApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutConflictApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.Conflict, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutForbiddenApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutForbiddenApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 403 (Forbidden) response.
+    /// </summary>
+    public class CheckoutForbiddenApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutForbiddenApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutForbiddenApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.Forbidden, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutHttpResponseMessage.cs
+++ b/src/CheckoutSdk/CheckoutHttpResponseMessage.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Base class for HTTP response messages received by the Checkout.com SDK for .NET.
+    /// </summary>
+    public class CheckoutHttpResponseMessage : HttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutHttpResponseMessage"/> instance with the provided HTTP status code.
+        /// </summary>
+        /// <param name="httpStatusCode">The HTTP status code of the API response.</param>
+        public CheckoutHttpResponseMessage(HttpStatusCode httpStatusCode)
+            : base(httpStatusCode) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutInternalServerErrorApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutInternalServerErrorApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 500 (Internal Server Error) response.
+    /// </summary>
+    public class CheckoutInternalServerErrorApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutInternalServerErrorApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutInternalServerErrorApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.InternalServerError, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutNoContentApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutNoContentApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 204 (No Content) response.
+    /// </summary>
+    public class CheckoutNoContentApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutNoContentApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutNoContentApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.NoContent, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutNotFoundApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutNotFoundApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 404 (Not Found) response.
+    /// </summary>
+    public class CheckoutNotFoundApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutNotFoundApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutNotFoundApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.NotFound, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutOkApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutOkApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 200 (OK) response.
+    /// </summary>
+    public class CheckoutOkApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutOkApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutOkApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.OK, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutTooManyRequestsApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutTooManyRequestsApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 429 (Too Many Requests) response.
+    /// </summary>
+    public class CheckoutTooManyRequestsApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutTooManyRequestsApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutTooManyRequestsApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base((HttpStatusCode)429, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutUnauthorizedApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutUnauthorizedApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 401 (Unauthorized) response.
+    /// </summary>
+    public class CheckoutUnauthorizedApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutUnauthorizedApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutUnauthorizedApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base(HttpStatusCode.Unauthorized, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/CheckoutUnprocessableEntityApiResponse.cs
+++ b/src/CheckoutSdk/CheckoutUnprocessableEntityApiResponse.cs
@@ -1,0 +1,18 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Checkout
+{
+    /// <summary>
+    /// Checkout API HTTP response message following a HTTP 422 (Unprocessable Entity) response.
+    /// </summary>
+    public class CheckoutUnprocessableEntityApiResponse : CheckoutApiHttpResponseMessage
+    {
+        /// <summary>
+        /// Creates a new <see cref="CheckoutUnprocessableEntityApiResponse"/> instance.
+        /// </summary>
+        /// <param name="httpResponseHeaders">The headers of the API response.</param>
+        public CheckoutUnprocessableEntityApiResponse(HttpResponseHeaders httpResponseHeaders = null) 
+            : base((HttpStatusCode)422, httpResponseHeaders) { }
+    }
+}

--- a/src/CheckoutSdk/Disputes/DisputesClient.cs
+++ b/src/CheckoutSdk/Disputes/DisputesClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,19 +35,19 @@ namespace Checkout.Disputes
             return _apiClient.GetAsync<Dispute>($"{path}/{id}", _credentials, cancellationToken);
         }
 
-        public Task<Type> AcceptDisputeAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<HttpResponseMessage> AcceptDisputeAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _apiClient.PostAsync<Type>($"{path}/{id}/accept", _credentials, cancellationToken, null);
+            return _apiClient.PostAsync<HttpResponseMessage>($"{path}/{id}/accept", _credentials, cancellationToken, null);
         }
 
-        public Task<Type> ProvideDisputeEvidenceAsync(string id, DisputeEvidence disputeEvidence, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<HttpResponseMessage> ProvideDisputeEvidenceAsync(string id, DisputeEvidence disputeEvidence, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _apiClient.PutAsync<Type>($"{path}/{id}/evidence", _credentials, cancellationToken, disputeEvidence);
+            return _apiClient.PutAsync<HttpResponseMessage>($"{path}/{id}/evidence", _credentials, cancellationToken, disputeEvidence);
         }
 
-        public Task<Type> SubmitDisputeEvidenceAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<HttpResponseMessage> SubmitDisputeEvidenceAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _apiClient.PostAsync<Type>($"{path}/{id}/evidence", _credentials, cancellationToken, null);
+            return _apiClient.PostAsync<HttpResponseMessage>($"{path}/{id}/evidence", _credentials, cancellationToken, null);
         }
 
         public Task<DisputeEvidenceResponse> GetDisputeEvidenceAsync(string id, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/CheckoutSdk/Disputes/IDisputesClient.cs
+++ b/src/CheckoutSdk/Disputes/IDisputesClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,7 +37,7 @@ namespace Checkout.Disputes
         /// <param name="id">The dispute identifier string.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the underlying HTTP request.</param>
         /// <returns>A void task.</returns>
-        Task<Type> AcceptDisputeAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpResponseMessage> AcceptDisputeAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Adds supporting evidence to a dispute. Before using this endpoint, you first need to upload your files using the file uploader.
@@ -47,7 +48,7 @@ namespace Checkout.Disputes
         /// <param name="disputeEvidence">The dictionary that maps dispute evidence files and their description to evidence types.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the underlying HTTP request.</param>
         /// <returns>A void task.</returns>
-        Task<Type> ProvideDisputeEvidenceAsync(string id, DisputeEvidence disputeEvidence, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpResponseMessage> ProvideDisputeEvidenceAsync(string id, DisputeEvidence disputeEvidence, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// With this final request, you can submit the evidence that you have previously provided.
@@ -57,7 +58,7 @@ namespace Checkout.Disputes
         /// <param name="id">The dispute identifier string.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the underlying HTTP request.</param>
         /// <returns>A void task.</returns>
-        Task<Type> SubmitDisputeEvidenceAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpResponseMessage> SubmitDisputeEvidenceAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Retrieves a list of the evidence submitted in response to a specific dispute.

--- a/src/CheckoutSdk/Webhooks/IWebhooksClient.cs
+++ b/src/CheckoutSdk/Webhooks/IWebhooksClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -55,6 +56,6 @@ namespace Checkout.Webhooks
         /// </summary>
         /// <param name="id">The webhook identifier.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the underlying HTTP request.</param>
-        Task<Type> RemoveWebhookAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpResponseMessage> RemoveWebhookAsync(string id, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/CheckoutSdk/Webhooks/WebhooksClient.cs
+++ b/src/CheckoutSdk/Webhooks/WebhooksClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -46,9 +47,9 @@ namespace Checkout.Webhooks
             return _apiClient.PatchAsync<WebhookResponse>($"{path}/{id}", _credentials, cancellationToken, webhookRequest);
         }
 
-        public Task<Type> RemoveWebhookAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<HttpResponseMessage> RemoveWebhookAsync(string id, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _apiClient.DeleteAsync<Type>($"{path}/{id}", _credentials, cancellationToken);
+            return _apiClient.DeleteAsync<HttpResponseMessage>($"{path}/{id}", _credentials, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Previously, if the API returned contentless responses such as 204 or 404, the SDK would not hand the result down to the merchant.

This PR aims at allowing the merchant tapping in the full API response economy of Checkout.com.