### PR TITLE
Make classes business classes inheritable

### DIFF
--- a/src/CheckoutSdk.Extensions/CheckoutOptions.cs
+++ b/src/CheckoutSdk.Extensions/CheckoutOptions.cs
@@ -1,10 +1,10 @@
-using System;
 using Checkout;
+using System;
 using Environment = Checkout.Environment;
 
 namespace CheckoutSDK.Extensions.Configuration
 {
-    public sealed class CheckoutOptions
+    public class CheckoutOptions
     {
         public string SecretKey { get; set; }
 

--- a/src/CheckoutSdk/AbstractClient.cs
+++ b/src/CheckoutSdk/AbstractClient.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout
 {
-    public class AbstractClient
+    public abstract class AbstractClient
     {
         protected readonly IApiClient ApiClient;
         private readonly CheckoutConfiguration _configuration;

--- a/src/CheckoutSdk/Apm/Ideal/CuriesLink.cs
+++ b/src/CheckoutSdk/Apm/Ideal/CuriesLink.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Apm.Ideal
 {
-    public sealed class CuriesLink
+    public class CuriesLink
     {
         public string Name { get; set; }
 

--- a/src/CheckoutSdk/Apm/Ideal/IdealCountry.cs
+++ b/src/CheckoutSdk/Apm/Ideal/IdealCountry.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Apm.Ideal
 {
-    public sealed class IdealCountry
+    public class IdealCountry
     {
         public string Name { get; set; }
 

--- a/src/CheckoutSdk/Apm/Ideal/IdealInfo.cs
+++ b/src/CheckoutSdk/Apm/Ideal/IdealInfo.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Apm.Ideal
 {
-    public sealed class IdealInfo
+    public class IdealInfo
     {
         [JsonProperty(PropertyName = "_links")]
         public IdealInfoLinks Links { get; set; }

--- a/src/CheckoutSdk/Apm/Ideal/IdealInfoLinks.cs
+++ b/src/CheckoutSdk/Apm/Ideal/IdealInfoLinks.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Apm.Ideal
 {
-    public sealed class IdealInfoLinks
+    public class IdealInfoLinks
     {
         public Link Self { get; set; }
 

--- a/src/CheckoutSdk/Apm/Ideal/Issuer.cs
+++ b/src/CheckoutSdk/Apm/Ideal/Issuer.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Apm.Ideal
 {
-    public sealed class Issuer
+    public class Issuer
     {
         public string Bic { get; set; }
 

--- a/src/CheckoutSdk/Apm/Ideal/IssuerResponse.cs
+++ b/src/CheckoutSdk/Apm/Ideal/IssuerResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Apm.Ideal
 {
-    public sealed class IssuerResponse : Resource
+    public class IssuerResponse : Resource
     {
         public IList<IdealCountry> Countries { get; set; }
     }

--- a/src/CheckoutSdk/Apm/Klarna/CreditSession.cs
+++ b/src/CheckoutSdk/Apm/Klarna/CreditSession.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Apm.Klarna
 {
-    public sealed class CreditSession : Resource
+    public class CreditSession : Resource
     {
         public string ClientToken { get; set; }
 

--- a/src/CheckoutSdk/Apm/Klarna/CreditSessionRequest.cs
+++ b/src/CheckoutSdk/Apm/Klarna/CreditSessionRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Apm.Klarna
 {
-    public sealed class CreditSessionRequest
+    public class CreditSessionRequest
     {
         public CountryCode? PurchaseCountry { get; set; }
 

--- a/src/CheckoutSdk/Apm/Klarna/CreditSessionResponse.cs
+++ b/src/CheckoutSdk/Apm/Klarna/CreditSessionResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Apm.Klarna
 {
-    public sealed class CreditSessionResponse : Resource
+    public class CreditSessionResponse : Resource
     {
         public string SessionId { get; set; }
 

--- a/src/CheckoutSdk/Apm/Klarna/Klarna.cs
+++ b/src/CheckoutSdk/Apm/Klarna/Klarna.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Apm.Klarna
 {
-    public sealed class Klarna
+    public class Klarna
     {
         public string Description { get; set; }
 

--- a/src/CheckoutSdk/Apm/Klarna/KlarnaProduct.cs
+++ b/src/CheckoutSdk/Apm/Klarna/KlarnaProduct.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Apm.Klarna
 {
-    public sealed class KlarnaProduct
+    public class KlarnaProduct
     {
         public string Name { get; set; }
 

--- a/src/CheckoutSdk/Apm/Klarna/KlarnaShippingInfo.cs
+++ b/src/CheckoutSdk/Apm/Klarna/KlarnaShippingInfo.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Apm.Klarna
 {
-    public sealed class KlarnaShippingInfo
+    public class KlarnaShippingInfo
     {
         public string ShippingCompany { get; set; }
 

--- a/src/CheckoutSdk/Apm/Klarna/OrderCaptureRequest.cs
+++ b/src/CheckoutSdk/Apm/Klarna/OrderCaptureRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Apm.Klarna
 {
-    public sealed class OrderCaptureRequest
+    public class OrderCaptureRequest
     {
         public const PaymentSourceType Type = PaymentSourceType.Klarna;
 

--- a/src/CheckoutSdk/Apm/Klarna/PaymentMethodCategory.cs
+++ b/src/CheckoutSdk/Apm/Klarna/PaymentMethodCategory.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Apm.Klarna
 {
-    public sealed class PaymentMethodCategory
+    public class PaymentMethodCategory
     {
         public string Identifier { get; set; }
 

--- a/src/CheckoutSdk/Apm/Klarna/PaymentMethodCategoryAssetUrl.cs
+++ b/src/CheckoutSdk/Apm/Klarna/PaymentMethodCategoryAssetUrl.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Apm.Klarna
 {
-    public sealed class PaymentMethodCategoryAssetUrl
+    public class PaymentMethodCategoryAssetUrl
     {
         public string Descriptive { get; set; }
 

--- a/src/CheckoutSdk/Apm/Sepa/MandateResponse.cs
+++ b/src/CheckoutSdk/Apm/Sepa/MandateResponse.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Checkout.Apm.Sepa
 {
-    public sealed class MandateResponse : Resource
+    public class MandateResponse : Resource
     {
         public string MandateReference { get; set; }
 

--- a/src/CheckoutSdk/CheckoutApiException.cs
+++ b/src/CheckoutSdk/CheckoutApiException.cs
@@ -16,7 +16,7 @@ namespace Checkout
             string requestId,
             HttpStatusCode httpStatusCode,
             IDictionary<string, object> errorDetails) :
-            base($"The API response status code ({(int) httpStatusCode}) does not indicate success.")
+            base($"The API response status code ({(int)httpStatusCode}) does not indicate success.")
         {
             RequestId = requestId;
             HttpStatusCode = httpStatusCode;

--- a/src/CheckoutSdk/Common/Address.cs
+++ b/src/CheckoutSdk/Common/Address.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Common
 {
-    public sealed class Address
+    public class Address
     {
         public string AddressLine1 { get; set; }
 

--- a/src/CheckoutSdk/Common/Four/AccountHolder.cs
+++ b/src/CheckoutSdk/Common/Four/AccountHolder.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Common.Four
 {
-    public sealed class AccountHolder
+    public class AccountHolder
     {
         public string FirstName { get; set; }
 

--- a/src/CheckoutSdk/Common/Four/BankDetails.cs
+++ b/src/CheckoutSdk/Common/Four/BankDetails.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Common.Four
 {
-    public sealed class BankDetails
+    public class BankDetails
     {
         public string Name { get; set; }
 

--- a/src/CheckoutSdk/Common/Four/UpdateCustomerRequest.cs
+++ b/src/CheckoutSdk/Common/Four/UpdateCustomerRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Common.Four
 {
-    public sealed class UpdateCustomerRequest
+    public class UpdateCustomerRequest
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Common/IdResponse.cs
+++ b/src/CheckoutSdk/Common/IdResponse.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Common
 {
-    public sealed class IdResponse : Resource
+    public class IdResponse : Resource
     {
         public string Id { get; set; }
     }

--- a/src/CheckoutSdk/Common/Link.cs
+++ b/src/CheckoutSdk/Common/Link.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Common
 {
-    public sealed class Link
+    public class Link
     {
         public string Href { get; set; }
 

--- a/src/CheckoutSdk/Common/MarketplaceData.cs
+++ b/src/CheckoutSdk/Common/MarketplaceData.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Common
 {
-    public sealed class MarketplaceData
+    public class MarketplaceData
     {
         public string SubEntityId { get; set; }
 

--- a/src/CheckoutSdk/Common/MarketplaceDataSubEntity.cs
+++ b/src/CheckoutSdk/Common/MarketplaceDataSubEntity.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Common
 {
-    public sealed class MarketplaceDataSubEntity
+    public class MarketplaceDataSubEntity
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Common/Phone.cs
+++ b/src/CheckoutSdk/Common/Phone.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Common
 {
-    public sealed class Phone
+    public class Phone
     {
         public string CountryCode { get; set; }
 

--- a/src/CheckoutSdk/Common/Product.cs
+++ b/src/CheckoutSdk/Common/Product.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Common
 {
-    public sealed class Product
+    public class Product
     {
         public string Name { get; set; }
 

--- a/src/CheckoutSdk/Common/QueryFilterDateRange.cs
+++ b/src/CheckoutSdk/Common/QueryFilterDateRange.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Common
 {
-    public sealed class QueryFilterDateRange
+    public class QueryFilterDateRange
     {
         public DateTime? From { get; set; }
 

--- a/src/CheckoutSdk/Customers/CustomerDetailsResponse.cs
+++ b/src/CheckoutSdk/Customers/CustomerDetailsResponse.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Customers
 {
-    public sealed class CustomerDetailsResponse
+    public class CustomerDetailsResponse
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Customers/CustomerRequest.cs
+++ b/src/CheckoutSdk/Customers/CustomerRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Customers
 {
-    public sealed class CustomerRequest
+    public class CustomerRequest
     {
         public string Email { get; set; }
 

--- a/src/CheckoutSdk/Customers/Four/CustomerRequest.cs
+++ b/src/CheckoutSdk/Customers/Four/CustomerRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Customers.Four
 {
-    public sealed class CustomerRequest
+    public class CustomerRequest
     {
         public string Email { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputeDetailsResponse.cs
+++ b/src/CheckoutSdk/Disputes/DisputeDetailsResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Disputes
 {
-    public sealed class DisputeDetailsResponse
+    public class DisputeDetailsResponse
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputeEvidenceRequest.cs
+++ b/src/CheckoutSdk/Disputes/DisputeEvidenceRequest.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Disputes
 {
-    public sealed class DisputeEvidenceRequest
+    public class DisputeEvidenceRequest
     {
         public string ProofOfDeliveryOrServiceFile { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputeEvidenceResponse.cs
+++ b/src/CheckoutSdk/Disputes/DisputeEvidenceResponse.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Disputes
 {
-    public sealed class DisputeEvidenceResponse
+    public class DisputeEvidenceResponse
     {
         public string ProofOfDeliveryOrServiceFile { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputeSummary.cs
+++ b/src/CheckoutSdk/Disputes/DisputeSummary.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Disputes
 {
-    public sealed class DisputeSummary : Resource
+    public class DisputeSummary : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputesQueryFilter.cs
+++ b/src/CheckoutSdk/Disputes/DisputesQueryFilter.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Disputes
 {
-    public sealed class DisputesQueryFilter
+    public class DisputesQueryFilter
     {
         public int? Limit { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputesQueryResponse.cs
+++ b/src/CheckoutSdk/Disputes/DisputesQueryResponse.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Disputes
 {
-    public sealed class DisputesQueryResponse
+    public class DisputesQueryResponse
     {
         public int? Limit { get; set; }
 

--- a/src/CheckoutSdk/Disputes/Four/DisputeDetailsResponse.cs
+++ b/src/CheckoutSdk/Disputes/Four/DisputeDetailsResponse.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Disputes.Four
 {
-    public sealed class DisputeDetailsResponse
+    public class DisputeDetailsResponse
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Disputes/Four/DisputeSummary.cs
+++ b/src/CheckoutSdk/Disputes/Four/DisputeSummary.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Disputes.Four
 {
-    public sealed class DisputeSummary : Resource
+    public class DisputeSummary : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Disputes/Four/DisputesQueryFilter.cs
+++ b/src/CheckoutSdk/Disputes/Four/DisputesQueryFilter.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Checkout.Disputes.Four
 {
-    public sealed class DisputesQueryFilter
+    public class DisputesQueryFilter
     {
         public int? Limit { get; set; }
 

--- a/src/CheckoutSdk/Disputes/Four/DisputesQueryResponse.cs
+++ b/src/CheckoutSdk/Disputes/Four/DisputesQueryResponse.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Disputes.Four
 {
-    public sealed class DisputesQueryResponse
+    public class DisputesQueryResponse
     {
         public int? Limit { get; set; }
 

--- a/src/CheckoutSdk/Disputes/Four/PaymentDispute.cs
+++ b/src/CheckoutSdk/Disputes/Four/PaymentDispute.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Disputes.Four
 {
-    public sealed class PaymentDispute
+    public class PaymentDispute
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Disputes/Four/ThreeDSVersionEnrollment.cs
+++ b/src/CheckoutSdk/Disputes/Four/ThreeDSVersionEnrollment.cs
@@ -2,7 +2,7 @@ using Checkout.Common.Four;
 
 namespace Checkout.Disputes.Four
 {
-    public sealed class ThreeDsVersionEnrollment
+    public class ThreeDsVersionEnrollment
     {
         public string Version { get; set; }
 

--- a/src/CheckoutSdk/Disputes/PaymentDispute.cs
+++ b/src/CheckoutSdk/Disputes/PaymentDispute.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Disputes
 {
-    public sealed class PaymentDispute
+    public class PaymentDispute
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Events/AttemptSummaryResponse.cs
+++ b/src/CheckoutSdk/Events/AttemptSummaryResponse.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Checkout.Events
 {
-    public sealed class AttemptSummaryResponse
+    public class AttemptSummaryResponse
     {
         public int? StatusCode { get; set; }
 

--- a/src/CheckoutSdk/Events/EventNotificationResponse.cs
+++ b/src/CheckoutSdk/Events/EventNotificationResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Events
 {
-    public sealed class EventNotificationResponse : Resource
+    public class EventNotificationResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Events/EventNotificationSummaryResponse.cs
+++ b/src/CheckoutSdk/Events/EventNotificationSummaryResponse.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Events
 {
-    public sealed class EventNotificationSummaryResponse : Resource
+    public class EventNotificationSummaryResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Events/EventResponse.cs
+++ b/src/CheckoutSdk/Events/EventResponse.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Events
 {
-    public sealed class EventResponse : Resource
+    public class EventResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Events/EventSummaryResponse.cs
+++ b/src/CheckoutSdk/Events/EventSummaryResponse.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Events
 {
-    public sealed class EventSummaryResponse : Resource
+    public class EventSummaryResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Events/EventTypeResponse.cs
+++ b/src/CheckoutSdk/Events/EventTypeResponse.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Events
 {
-    public sealed class EventTypesResponse
+    public class EventTypesResponse
     {
         public string Version { get; set; }
 

--- a/src/CheckoutSdk/Events/EventsPageResponse.cs
+++ b/src/CheckoutSdk/Events/EventsPageResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Events
 {
-    public sealed class EventsPageResponse
+    public class EventsPageResponse
     {
         public int? TotalCount { get; set; }
 

--- a/src/CheckoutSdk/Events/RetrieveEventsRequest.cs
+++ b/src/CheckoutSdk/Events/RetrieveEventsRequest.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Checkout.Events
 {
-    public sealed class RetrieveEventsRequest
+    public class RetrieveEventsRequest
     {
         public string PaymentId { get; set; }
 

--- a/src/CheckoutSdk/Files/FileDetailsResponse.cs
+++ b/src/CheckoutSdk/Files/FileDetailsResponse.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Files
 {
-    public sealed class FileDetailsResponse : Resource
+    public class FileDetailsResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Forex/QuoteRequest.cs
+++ b/src/CheckoutSdk/Forex/QuoteRequest.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Forex
 {
-    public sealed class QuoteRequest
+    public class QuoteRequest
     {
         public Currency? SourceCurrency { get; set; }
 

--- a/src/CheckoutSdk/Forex/QuoteResponse.cs
+++ b/src/CheckoutSdk/Forex/QuoteResponse.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Forex
 {
-    public sealed class QuoteResponse
+    public class QuoteResponse
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Instruments/CreateInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/CreateInstrumentRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments
 {
-    public sealed class CreateInstrumentRequest
+    public class CreateInstrumentRequest
     {
         public InstrumentType Type => InstrumentType.Token;
 

--- a/src/CheckoutSdk/Instruments/CreateInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/CreateInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments
 {
-    public sealed class CreateInstrumentResponse
+    public class CreateInstrumentResponse
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Instruments/Four/Create/CreateBankAccountInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateBankAccountInstrumentRequest.cs
@@ -3,7 +3,7 @@ using Checkout.Common.Four;
 
 namespace Checkout.Instruments.Four.Create
 {
-    public sealed class CreateBankAccountInstrumentRequest : CreateInstrumentRequest
+    public class CreateBankAccountInstrumentRequest : CreateInstrumentRequest
     {
         public CreateBankAccountInstrumentRequest() : base(InstrumentType.BankAccount)
         {

--- a/src/CheckoutSdk/Instruments/Four/Create/CreateBankAccountInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateBankAccountInstrumentResponse.cs
@@ -3,7 +3,7 @@ using Checkout.Common.Four;
 
 namespace Checkout.Instruments.Four.Create
 {
-    public sealed class CreateBankAccountInstrumentResponse : CreateInstrumentResponse
+    public class CreateBankAccountInstrumentResponse : CreateInstrumentResponse
     {
         public CreateBankAccountInstrumentResponse() : base(InstrumentType.BankAccount)
         {

--- a/src/CheckoutSdk/Instruments/Four/Create/CreateCustomerInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateCustomerInstrumentRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Create
 {
-    public sealed class CreateCustomerInstrumentRequest
+    public class CreateCustomerInstrumentRequest
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Instruments/Four/Create/CreateTokenInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateTokenInstrumentRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Create
 {
-    public sealed class CreateTokenInstrumentRequest : CreateInstrumentRequest
+    public class CreateTokenInstrumentRequest : CreateInstrumentRequest
     {
         public CreateTokenInstrumentRequest() : base(InstrumentType.Token)
         {

--- a/src/CheckoutSdk/Instruments/Four/Create/CreateTokenInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateTokenInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Create
 {
-    public sealed class CreateTokenInstrumentResponse : CreateInstrumentResponse
+    public class CreateTokenInstrumentResponse : CreateInstrumentResponse
     {
         public CreateTokenInstrumentResponse() : base(InstrumentType.Card)
         {

--- a/src/CheckoutSdk/Instruments/Four/Get/GetBankAccountInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Get/GetBankAccountInstrumentResponse.cs
@@ -3,7 +3,7 @@ using Checkout.Common.Four;
 
 namespace Checkout.Instruments.Four.Get
 {
-    public sealed class GetBankAccountInstrumentResponse : GetInstrumentResponse
+    public class GetBankAccountInstrumentResponse : GetInstrumentResponse
     {
         public GetBankAccountInstrumentResponse() : base(InstrumentType.BankAccount)
         {

--- a/src/CheckoutSdk/Instruments/Four/Get/GetCardInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Get/GetCardInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Get
 {
-    public sealed class GetCardInstrumentResponse : GetInstrumentResponse
+    public class GetCardInstrumentResponse : GetInstrumentResponse
     {
         public GetCardInstrumentResponse() : base(InstrumentType.Card)
         {

--- a/src/CheckoutSdk/Instruments/Four/Get/Util/GetInstrumentResponseTypeConverter.cs
+++ b/src/CheckoutSdk/Instruments/Four/Get/Util/GetInstrumentResponseTypeConverter.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace Checkout.Instruments.Four.Get.Util
 {
-    public sealed class GetInstrumentResponseTypeConverter : JsonConverter
+    public class GetInstrumentResponseTypeConverter : JsonConverter
     {
         public override bool CanWrite => false;
 

--- a/src/CheckoutSdk/Instruments/Four/Update/UpdateBankInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/Four/Update/UpdateBankInstrumentRequest.cs
@@ -3,7 +3,7 @@ using Checkout.Common.Four;
 
 namespace Checkout.Instruments.Four.Update
 {
-    public sealed class UpdateBankInstrumentRequest : UpdateInstrumentRequest
+    public class UpdateBankInstrumentRequest : UpdateInstrumentRequest
     {
         public UpdateBankInstrumentRequest() : base(InstrumentType.BankAccount)
         {

--- a/src/CheckoutSdk/Instruments/Four/Update/UpdateBankInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Update/UpdateBankInstrumentResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments.Four.Update
 {
-    public sealed class UpdateBankInstrumentResponse : UpdateInstrumentResponse
+    public class UpdateBankInstrumentResponse : UpdateInstrumentResponse
     {
         public UpdateBankInstrumentResponse() : base(InstrumentType.BankAccount)
         {

--- a/src/CheckoutSdk/Instruments/Four/Update/UpdateCardInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/Four/Update/UpdateCardInstrumentRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Update
 {
-    public sealed class UpdateCardInstrumentRequest : UpdateInstrumentRequest
+    public class UpdateCardInstrumentRequest : UpdateInstrumentRequest
     {
         public UpdateCardInstrumentRequest() : base(InstrumentType.Card)
         {

--- a/src/CheckoutSdk/Instruments/Four/Update/UpdateCardInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Update/UpdateCardInstrumentResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments.Four.Update
 {
-    public sealed class UpdateCardInstrumentResponse : UpdateInstrumentResponse
+    public class UpdateCardInstrumentResponse : UpdateInstrumentResponse
     {
         public UpdateCardInstrumentResponse() : base(InstrumentType.Card)
         {

--- a/src/CheckoutSdk/Instruments/Four/Update/UpdateTokenInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/Four/Update/UpdateTokenInstrumentRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments.Four.Update
 {
-    public sealed class UpdateTokenInstrumentRequest : UpdateInstrumentRequest
+    public class UpdateTokenInstrumentRequest : UpdateInstrumentRequest
     {
         public UpdateTokenInstrumentRequest() : base(InstrumentType.Token)
         {

--- a/src/CheckoutSdk/Instruments/InstrumentAccountHolder.cs
+++ b/src/CheckoutSdk/Instruments/InstrumentAccountHolder.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments
 {
-    public sealed class InstrumentAccountHolder
+    public class InstrumentAccountHolder
     {
         public Address BillingAddress { get; set; }
 

--- a/src/CheckoutSdk/Instruments/InstrumentCustomerRequest.cs
+++ b/src/CheckoutSdk/Instruments/InstrumentCustomerRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments
 {
-    public sealed class InstrumentCustomerRequest : CustomerRequest
+    public class InstrumentCustomerRequest : CustomerRequest
     {
         public bool Default { get; set; }
 

--- a/src/CheckoutSdk/Instruments/InstrumentCustomerResponse.cs
+++ b/src/CheckoutSdk/Instruments/InstrumentCustomerResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments
 {
-    public sealed class InstrumentCustomerResponse : CustomerResponse
+    public class InstrumentCustomerResponse : CustomerResponse
     {
         public bool Default { get; set; }
     }

--- a/src/CheckoutSdk/Instruments/RetrieveInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/RetrieveInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments
 {
-    public sealed class RetrieveInstrumentResponse
+    public class RetrieveInstrumentResponse
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Instruments/UpdateInstrumentRequest.cs
+++ b/src/CheckoutSdk/Instruments/UpdateInstrumentRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments
 {
-    public sealed class UpdateInstrumentRequest
+    public class UpdateInstrumentRequest
     {
         public int? ExpiryMonth { get; set; }
 
@@ -12,7 +12,7 @@
 
         public UpdateInstrumentCustomer Customer { get; set; }
 
-        public sealed class UpdateInstrumentCustomer
+        public class UpdateInstrumentCustomer
         {
             public string Id { get; set; }
 

--- a/src/CheckoutSdk/Instruments/UpdateInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/UpdateInstrumentResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments
 {
-    public sealed class UpdateInstrumentResponse
+    public class UpdateInstrumentResponse
     {
         public InstrumentType? Type { get; set; }
 

--- a/src/CheckoutSdk/Payments/BillingDescriptor.cs
+++ b/src/CheckoutSdk/Payments/BillingDescriptor.cs
@@ -1,10 +1,9 @@
 namespace Checkout.Payments
 {
-    public sealed class BillingDescriptor 
+    public class BillingDescriptor
     {
         public string Name { get; set; }
 
         public string City { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/BillingInformation.cs
+++ b/src/CheckoutSdk/Payments/BillingInformation.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments
 {
-    public sealed class BillingInformation 
+    public class BillingInformation 
     {
         public Address Address { get; set; }
 

--- a/src/CheckoutSdk/Payments/CaptureRequest.cs
+++ b/src/CheckoutSdk/Payments/CaptureRequest.cs
@@ -2,13 +2,12 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments
 {
-    public sealed class CaptureRequest
+    public class CaptureRequest
     {
         public long? Amount { get; set; }
 
         public string Reference { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
-      
     }
 }

--- a/src/CheckoutSdk/Payments/CaptureResponse.cs
+++ b/src/CheckoutSdk/Payments/CaptureResponse.cs
@@ -2,11 +2,10 @@ using Checkout.Common;
 
 namespace Checkout.Payments
 {
-    public sealed class CaptureResponse : Resource
+    public class CaptureResponse : Resource
     {
         public string ActionId { get; set; }
 
         public string Reference { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Four/BillingDescriptor.cs
+++ b/src/CheckoutSdk/Payments/Four/BillingDescriptor.cs
@@ -1,12 +1,11 @@
 namespace Checkout.Payments.Four
 {
-    public sealed class BillingDescriptor 
+    public class BillingDescriptor
     {
         public string Name { get; set; }
 
         public string City { get; set; }
 
         public string Reference { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Four/CaptureRequest.cs
+++ b/src/CheckoutSdk/Payments/Four/CaptureRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four
 {
-    public sealed class CaptureRequest 
+    public class CaptureRequest
     {
         public long? Amount { get; set; }
 
@@ -11,6 +11,5 @@ namespace Checkout.Payments.Four
         public string Reference { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
-      
     }
 }

--- a/src/CheckoutSdk/Payments/Four/CaptureResponse.cs
+++ b/src/CheckoutSdk/Payments/Four/CaptureResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four
 {
-    public sealed class CaptureResponse : Resource
+    public class CaptureResponse : Resource
     {
         public string ActionId { get; set; }
 

--- a/src/CheckoutSdk/Payments/Four/PaymentAction.cs
+++ b/src/CheckoutSdk/Payments/Four/PaymentAction.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Four
 {
-    public sealed class PaymentAction
+    public class PaymentAction
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Payments/Four/RefundRequest.cs
+++ b/src/CheckoutSdk/Payments/Four/RefundRequest.cs
@@ -2,13 +2,12 @@
 
 namespace Checkout.Payments.Four
 {
-    public sealed class RefundRequest 
+    public class RefundRequest
     {
         public long? Amount { get; set; }
 
         public string Reference { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
-
     }
 }

--- a/src/CheckoutSdk/Payments/Four/RefundResponse.cs
+++ b/src/CheckoutSdk/Payments/Four/RefundResponse.cs
@@ -2,11 +2,10 @@
 
 namespace Checkout.Payments.Four
 {
-    public sealed class RefundResponse : Resource
+    public class RefundResponse : Resource
     {
         public string ActionId { get; set; }
 
         public string Reference { get; set; }
-     
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/Destination/PaymentRequestBankAccountDestination.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Destination/PaymentRequestBankAccountDestination.cs
@@ -3,7 +3,7 @@ using Checkout.Common.Four;
 
 namespace Checkout.Payments.Four.Request.Destination
 {
-    public sealed class PaymentBankAccountDestination : PaymentRequestDestination
+    public class PaymentBankAccountDestination : PaymentRequestDestination
     {
         public PaymentBankAccountDestination() : base(PaymentDestinationType.BankAccount)
         {
@@ -26,6 +26,5 @@ namespace Checkout.Payments.Four.Request.Destination
         public AccountHolder AccountHolder { get; set; }
 
         public BankDetails Bank { get; set; }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/Destination/PaymentRequestIdDestination.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Destination/PaymentRequestIdDestination.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Payments.Four.Request.Destination
 {
-    public sealed class PaymentRequestIdDestination : PaymentRequestDestination
+    public class PaymentRequestIdDestination : PaymentRequestDestination
     {
         public PaymentRequestIdDestination() : base(PaymentDestinationType.Id)
         {

--- a/src/CheckoutSdk/Payments/Four/Request/PaymentInstruction.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/PaymentInstruction.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Payments.Four.Request
 {
-    public sealed class PaymentInstruction 
+    public class PaymentInstruction
     {
         public string Purpose { get; set; }
 
@@ -11,6 +11,5 @@ namespace Checkout.Payments.Four.Request
         public InstructionScheme? Scheme { get; set; }
 
         public string QuoteId { get; set; }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/PaymentRequest.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/PaymentRequest.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Four.Request
 {
-    public sealed class PaymentRequest 
+    public class PaymentRequest
     {
         public AbstractRequestSource Source { get; set; }
 
@@ -58,6 +58,5 @@ namespace Checkout.Payments.Four.Request
         public ProcessingSettings Processing { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/PayoutBillingDescriptor.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/PayoutBillingDescriptor.cs
@@ -1,8 +1,7 @@
 namespace Checkout.Payments.Four.Request
 {
-    public sealed class PayoutBillingDescriptor 
+    public class PayoutBillingDescriptor
     {
         public string Reference { get; set; }
-        
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/PayoutRequest.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/PayoutRequest.cs
@@ -5,7 +5,7 @@ using Checkout.Payments.Four.Sender;
 
 namespace Checkout.Payments.Four.Request
 {
-    public sealed class PayoutRequest 
+    public class PayoutRequest 
     {
         public PayoutRequestSource Source { get; set; }
 

--- a/src/CheckoutSdk/Payments/Four/Request/Source/Apm/RequestIdealSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Source/Apm/RequestIdealSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Request.Source.Apm
 {
-    public sealed class RequestIdealSource : AbstractRequestSource
+    public class RequestIdealSource : AbstractRequestSource
     {
         public RequestIdealSource() : base(PaymentSourceType.Ideal)
         {
@@ -13,6 +13,5 @@ namespace Checkout.Payments.Four.Request.Source.Apm
         public string Description { get; set; }
 
         public string Language { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/Source/Apm/RequestSofortSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Source/Apm/RequestSofortSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Request.Source.Apm
 {
-    public sealed class RequestSofortSource : AbstractRequestSource
+    public class RequestSofortSource : AbstractRequestSource
     {
         public RequestSofortSource() : base(PaymentSourceType.Sofort)
         {

--- a/src/CheckoutSdk/Payments/Four/Request/Source/PayoutRequestCurrencyAccountSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Source/PayoutRequestCurrencyAccountSource.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Payments.Four.Request.Source
 {
-    public sealed class PayoutRequestCurrencyAccountSource : PayoutRequestSource
+    public class PayoutRequestCurrencyAccountSource : PayoutRequestSource
     {
         public PayoutRequestCurrencyAccountSource() : base(PayoutSourceType.CurrencyAccount)
         {

--- a/src/CheckoutSdk/Payments/Four/Request/Source/RequestCardSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Source/RequestCardSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Request.Source
 {
-    public sealed class RequestCardSource : AbstractRequestSource
+    public class RequestCardSource : AbstractRequestSource
     {
         public RequestCardSource() : base(PaymentSourceType.Card)
         {
@@ -23,6 +23,5 @@ namespace Checkout.Payments.Four.Request.Source
         public Address BillingAddress { get; set; }
 
         public Phone Phone { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/Source/RequestIdSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Source/RequestIdSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Request.Source
 {
-    public sealed class RequestIdSource : AbstractRequestSource
+    public class RequestIdSource : AbstractRequestSource
     {
         public RequestIdSource() : base(PaymentSourceType.Id)
         {
@@ -11,6 +11,5 @@ namespace Checkout.Payments.Four.Request.Source
         public string Id { get; set; }
 
         public string Cvv { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/Source/RequestNetworkTokenSourcee.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Source/RequestNetworkTokenSourcee.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Request.Source
 {
-    public sealed class RequestNetworkTokenSource : AbstractRequestSource
+    public class RequestNetworkTokenSource : AbstractRequestSource
     {
         public RequestNetworkTokenSource() : base(PaymentSourceType.NetworkToken)
         {
@@ -29,6 +29,5 @@ namespace Checkout.Payments.Four.Request.Source
         public Address BillingAddress { get; set; }
 
         public Phone Phone { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Request/Source/RequestTokenSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Request/Source/RequestTokenSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Request.Source
 {
-    public sealed class RequestTokenSource : AbstractRequestSource
+    public class RequestTokenSource : AbstractRequestSource
     {
         public RequestTokenSource() : base(PaymentSourceType.Token)
         {
@@ -13,6 +13,5 @@ namespace Checkout.Payments.Four.Request.Source
         public Address BillingAddress { get; set; }
 
         public Phone Phone { get; set; }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Response/Destination/PaymentResponseBankAccountDestination.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/Destination/PaymentResponseBankAccountDestination.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Response.Destination
 {
-    public sealed class PaymentResponseBankAccountDestination : AbstractPaymentResponseDestination,
+    public class PaymentResponseBankAccountDestination : AbstractPaymentResponseDestination,
         IPaymentResponseDestination
     {
         public int? ExpiryMonth { get; set; }
@@ -33,6 +33,5 @@ namespace Checkout.Payments.Four.Response.Destination
         {
             return base.Type;
         }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Response/GetPaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/GetPaymentResponse.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Four.Response
 {
-    public sealed class GetPaymentResponse : Resource
+    public class GetPaymentResponse : Resource
     {
         public string Id { get; set; }
 
@@ -65,6 +65,5 @@ namespace Checkout.Payments.Four.Response
         public string SchemeId { get; set; }
 
         public IList<PaymentActionSummary> Actions { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Response/PaymentInstructionResponse.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/PaymentInstructionResponse.cs
@@ -3,9 +3,8 @@ using System;
 
 namespace Checkout.Payments.Four.Response
 {
-    public sealed class PaymentInstructionResponse : Resource
+    public class PaymentInstructionResponse : Resource
     {
         public DateTime? ValueDate { get; set; }
-     
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Response/PaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/PaymentResponse.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Checkout.Payments.Four.Response
 {
-    public sealed class PaymentResponse : Resource
+    public class PaymentResponse : Resource
     {
         public string ActionId { get; set; }
 
@@ -48,6 +48,5 @@ namespace Checkout.Payments.Four.Response
         public string Eci { get; set; }
 
         public string SchemeId { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Response/PaymentResponseBalances.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/PaymentResponseBalances.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Payments.Four.Response
 {
-    public sealed class PaymentResponseBalances 
+    public class PaymentResponseBalances
     {
         public long? TotalAuthorized { get; set; }
 
@@ -15,6 +15,5 @@ namespace Checkout.Payments.Four.Response
         public long? TotalRefunded { get; set; }
 
         public long? AvailableToRefund { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Response/PayoutResponse.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/PayoutResponse.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Payments.Four.Response
 {
-    public sealed class PayoutResponse : Resource
+    public class PayoutResponse : Resource
     {
         public string Id { get; set; }
 
@@ -11,6 +11,5 @@ namespace Checkout.Payments.Four.Response
         public string Reference { get; set; }
 
         public PaymentInstructionResponse Instruction { get; set; }
-             
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Response/Source/CardResponseSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/Source/CardResponseSource.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Payments.Four.Response.Source
 {
-    public sealed class CardResponseSource : AbstractResponseSource, IResponseSource
+    public class CardResponseSource : AbstractResponseSource, IResponseSource
     {
         public int? ExpiryMonth { get; set; }
 

--- a/src/CheckoutSdk/Payments/Four/Response/Source/CurrencyAccountResponseSource.cs
+++ b/src/CheckoutSdk/Payments/Four/Response/Source/CurrencyAccountResponseSource.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Payments.Four.Response.Source
 {
-    public sealed class CurrencyAccountResponseSource : AbstractResponseSource, IResponseSource
+    public class CurrencyAccountResponseSource : AbstractResponseSource, IResponseSource
     {
         public long? Amount { get; set; }
 
@@ -10,6 +10,5 @@ namespace Checkout.Payments.Four.Response.Source
         {
             return base.Type;
         }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Sender/PaymentCorporateSender.cs
+++ b/src/CheckoutSdk/Payments/Four/Sender/PaymentCorporateSender.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Sender
 {
-    public sealed class PaymentCorporateSender : PaymentSender
+    public class PaymentCorporateSender : PaymentSender
     {
         public PaymentCorporateSender() : base(PaymentSenderType.Corporate)
         {
@@ -11,6 +11,5 @@ namespace Checkout.Payments.Four.Sender
         public string CompanyName { get; set; }
 
         public Address Address { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Sender/PaymentIndividualSender.cs
+++ b/src/CheckoutSdk/Payments/Four/Sender/PaymentIndividualSender.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four.Sender
 {
-    public sealed class PaymentIndividualSender : PaymentSender
+    public class PaymentIndividualSender : PaymentSender
     {
         public PaymentIndividualSender() : base(PaymentSenderType.Individual)
         {
@@ -13,6 +13,5 @@ namespace Checkout.Payments.Four.Sender
         public string LastName { get; set; }
 
         public Address Address { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Four/Sender/PaymentInstrumentSender.cs
+++ b/src/CheckoutSdk/Payments/Four/Sender/PaymentInstrumentSender.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Payments.Four.Sender
 {
-    public sealed class PaymentInstrumentSender : PaymentSender
+    public class PaymentInstrumentSender : PaymentSender
     {
         public PaymentInstrumentSender() : base(PaymentSenderType.Instrument)
         {

--- a/src/CheckoutSdk/Payments/Four/Util/PaymentResponseSourceTypeConverter.cs
+++ b/src/CheckoutSdk/Payments/Four/Util/PaymentResponseSourceTypeConverter.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace Checkout.Payments.Four.Util
 {
-    public sealed class PaymentResponseSourceTypeConverter : JsonConverter
+    public class PaymentResponseSourceTypeConverter : JsonConverter
     {
         public override bool CanWrite => false;
 

--- a/src/CheckoutSdk/Payments/Four/VoidRequest.cs
+++ b/src/CheckoutSdk/Payments/Four/VoidRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four
 {
-    public sealed class VoidRequest 
+    public class VoidRequest 
     {
         public string Reference { get; set; }
 

--- a/src/CheckoutSdk/Payments/Four/VoidResponse.cs
+++ b/src/CheckoutSdk/Payments/Four/VoidResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Four
 {
-    public sealed class VoidResponse : Resource
+    public class VoidResponse : Resource
     {
         public string ActionId { get; set; }
 

--- a/src/CheckoutSdk/Payments/Hosted/HostedPaymentDetailsResponse.cs
+++ b/src/CheckoutSdk/Payments/Hosted/HostedPaymentDetailsResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Hosted
 {
-    public sealed class HostedPaymentDetailsResponse : Resource
+    public class HostedPaymentDetailsResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Payments/Hosted/HostedPaymentRequest.cs
+++ b/src/CheckoutSdk/Payments/Hosted/HostedPaymentRequest.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Hosted
 {
-    public sealed class HostedPaymentRequest
+    public class HostedPaymentRequest
     {
         public long? Amount { get; set; }
 

--- a/src/CheckoutSdk/Payments/Hosted/HostedPaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/Hosted/HostedPaymentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Hosted
 {
-    public sealed class HostedPaymentResponse : Resource
+    public class HostedPaymentResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Payments/Links/PaymentLinkDetailsResponse.cs
+++ b/src/CheckoutSdk/Payments/Links/PaymentLinkDetailsResponse.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Links
 {
-    public sealed class PaymentLinkDetailsResponse : Resource
+    public class PaymentLinkDetailsResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Payments/Links/PaymentLinkRequest.cs
+++ b/src/CheckoutSdk/Payments/Links/PaymentLinkRequest.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Links
 {
-    public sealed class PaymentLinkRequest 
+    public class PaymentLinkRequest 
     {
         public long? Amount { get; set; }
 

--- a/src/CheckoutSdk/Payments/Links/PaymentLinkResponse.cs
+++ b/src/CheckoutSdk/Payments/Links/PaymentLinkResponse.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Payments.Links
 {
-    public sealed class PaymentLinkResponse : Resource
+    public class PaymentLinkResponse : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Payments/PaymentAction.cs
+++ b/src/CheckoutSdk/Payments/PaymentAction.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments
 {
-    public sealed class PaymentAction : Resource
+    public class PaymentAction : Resource
     {
         public string Id { get; set; }
 
@@ -27,6 +27,5 @@ namespace Checkout.Payments
         public Processing Processing { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/PaymentActionSummary.cs
+++ b/src/CheckoutSdk/Payments/PaymentActionSummary.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Payments
 {
-    public sealed class PaymentActionSummary
+    public class PaymentActionSummary
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Payments/PaymentProcessing.cs
+++ b/src/CheckoutSdk/Payments/PaymentProcessing.cs
@@ -1,14 +1,11 @@
-using System;
-
 namespace Checkout.Payments
 {
-    public sealed class PaymentProcessing 
+    public class PaymentProcessing
     {
         public string RetrievalReferenceNumber { get; set; }
 
         public string AcquirerTransactionId { get; set; }
 
         public string RecommendationCode { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/PaymentRecipient.cs
+++ b/src/CheckoutSdk/Payments/PaymentRecipient.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace Checkout.Payments
 {
-    public sealed class PaymentRecipient 
+    public class PaymentRecipient
     {
         [JsonProperty("dob")] public string DateOfBirth { get; set; }
 
@@ -16,6 +16,5 @@ namespace Checkout.Payments
         public string LastName { get; set; }
 
         public CountryCode? Country { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Processing.cs
+++ b/src/CheckoutSdk/Payments/Processing.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Payments
 {
-    public sealed class Processing 
+    public class Processing 
     {
         public string AcquirerReferenceNumber { get; set; }
 

--- a/src/CheckoutSdk/Payments/ProcessingSettings.cs
+++ b/src/CheckoutSdk/Payments/ProcessingSettings.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Payments
 {
-    public sealed class ProcessingSettings 
+    public class ProcessingSettings 
     {
         public bool? Aft { get; set; }
             

--- a/src/CheckoutSdk/Payments/RefundRequest.cs
+++ b/src/CheckoutSdk/Payments/RefundRequest.cs
@@ -2,13 +2,12 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments
 {
-    public sealed class RefundRequest 
+    public class RefundRequest
     {
         public long? Amount { get; set; }
 
         public string Reference { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
-             
     }
 }

--- a/src/CheckoutSdk/Payments/RefundResponse.cs
+++ b/src/CheckoutSdk/Payments/RefundResponse.cs
@@ -2,11 +2,10 @@ using Checkout.Common;
 
 namespace Checkout.Payments
 {
-    public sealed class RefundResponse : Resource
+    public class RefundResponse : Resource
     {
         public string ActionId { get; set; }
 
         public string Reference { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Destination/PaymentRequestCardDestination.cs
+++ b/src/CheckoutSdk/Payments/Request/Destination/PaymentRequestCardDestination.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Destination
 {
-    public sealed class PaymentRequestCardDestination : PaymentRequestDestination
+    public class PaymentRequestCardDestination : PaymentRequestDestination
     {
         public PaymentRequestCardDestination() : base(PaymentDestinationType.Card)
         {

--- a/src/CheckoutSdk/Payments/Request/Destination/PaymentRequestIdDestination.cs
+++ b/src/CheckoutSdk/Payments/Request/Destination/PaymentRequestIdDestination.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Payments.Request.Destination
 {
-    public sealed class PaymentRequestIdDestination : PaymentRequestDestination
+    public class PaymentRequestIdDestination : PaymentRequestDestination
     {
         public PaymentRequestIdDestination() : base(PaymentDestinationType.Id)
         {

--- a/src/CheckoutSdk/Payments/Request/Destination/PaymentRequestTokenDestination.cs
+++ b/src/CheckoutSdk/Payments/Request/Destination/PaymentRequestTokenDestination.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Destination
 {
-    public sealed class PaymentRequestTokenDestination : PaymentRequestDestination
+    public class PaymentRequestTokenDestination : PaymentRequestDestination
     {
         public PaymentRequestTokenDestination() : base(PaymentDestinationType.Token)
         {

--- a/src/CheckoutSdk/Payments/Request/PaymentRequest.cs
+++ b/src/CheckoutSdk/Payments/Request/PaymentRequest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Request
 {
-    public sealed class PaymentRequest 
+    public class PaymentRequest 
     {
         public AbstractRequestSource Source { get; set; }
 

--- a/src/CheckoutSdk/Payments/Request/PayoutRequest.cs
+++ b/src/CheckoutSdk/Payments/Request/PayoutRequest.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Request
 {
-    public sealed class PayoutRequest
+    public class PayoutRequest
     {
         public PaymentRequestDestination Destination { get; set; }
 

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/BalotoPayer.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/BalotoPayer.cs
@@ -1,10 +1,9 @@
 ﻿namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class BalotoPayer 
+    public class BalotoPayer
     {
         public string Name { get; set; }
 
         public string Email { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/FawryProduct.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/FawryProduct.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-namespace Checkout.Payments.Request.Source.Apm
+﻿namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class FawryProduct 
+    public class FawryProduct
     {
         public string ProductId { get; set; }
 
@@ -11,6 +9,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public long? Price { get; set; }
 
         public string Description { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/KlarnaCustomer.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/KlarnaCustomer.cs
@@ -1,10 +1,9 @@
 ﻿namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class KlarnaCustomer 
+    public class KlarnaCustomer
     {
         public string DateOfBirth { get; set; }
 
         public string Gender { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/KlarnaProduct.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/KlarnaProduct.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class KlarnaProduct 
+    public class KlarnaProduct
     {
         public string Name { get; set; }
 
@@ -13,6 +13,5 @@
         public long? TotalAmount { get; set; }
 
         public long? TotalTaxAmount { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/Payer.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/Payer.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class Payer 
+    public class Payer 
     {
         public string Name { get; set; }
 

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestBalotoSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestBalotoSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestBalotoSource : AbstractRequestSource
+    public class RequestBalotoSource : AbstractRequestSource
     {
         public RequestBalotoSource() : base(PaymentSourceType.Baloto)
         {
@@ -15,6 +15,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public BalotoPayer Payer { get; set; }
 
         public string Description { get; set; }
-      
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestBoletoSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestBoletoSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestBoletoSource : AbstractRequestSource
+    public class RequestBoletoSource : AbstractRequestSource
     {
         public RequestBoletoSource() : base(PaymentSourceType.Boleto)
         {
@@ -15,6 +15,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public Payer Payer { get; set; }
 
         public string Description { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestFawrySource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestFawrySource.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestFawrySource : AbstractRequestSource
+    public class RequestFawrySource : AbstractRequestSource
     {
         public RequestFawrySource() : base(PaymentSourceType.Fawry)
         {
@@ -16,6 +16,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public string CustomerEmail { get; set; }
 
         public IList<FawryProduct> Products { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestGiropaySource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestGiropaySource.cs
@@ -2,13 +2,12 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestGiropaySource : AbstractRequestSource
+    public class RequestGiropaySource : AbstractRequestSource
     {
         public RequestGiropaySource() : base(PaymentSourceType.Giropay)
         {
         }
 
         public string Purpose { get; set; }
-     
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestIdealSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestIdealSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestIdealSource : AbstractRequestSource
+    public class RequestIdealSource : AbstractRequestSource
     {
         public RequestIdealSource() : base(PaymentSourceType.Ideal)
         {
@@ -13,6 +13,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public string Description { get; set; }
 
         public string Language { get; set; }
-      
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestKlarnaSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestKlarnaSource.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestKlarnaSource : AbstractRequestSource
+    public class RequestKlarnaSource : AbstractRequestSource
     {
         public RequestKlarnaSource() : base(PaymentSourceType.Klarna)
         {
@@ -22,6 +22,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public KlarnaCustomer Customer { get; set; }
 
         public IList<KlarnaCustomer> Products { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestOxxoSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestOxxoSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestOxxoSource : AbstractRequestSource
+    public class RequestOxxoSource : AbstractRequestSource
     {
         public RequestOxxoSource() : base(PaymentSourceType.Oxxo)
         {
@@ -15,6 +15,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public Payer Payer { get; set; }
 
         public string Description { get; set; }
-       
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestPagoFacilSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestPagoFacilSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestPagoFacilSource : AbstractRequestSource
+    public class RequestPagoFacilSource : AbstractRequestSource
     {
         public RequestPagoFacilSource() : base(PaymentSourceType.PagoFacil)
         {
@@ -15,6 +15,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public Payer Payer { get; set; }
 
         public string Description { get; set; }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestRapiPagoSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestRapiPagoSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestRapiPagoSource : AbstractRequestSource
+    public class RequestRapiPagoSource : AbstractRequestSource
     {
         public RequestRapiPagoSource() : base(PaymentSourceType.RapiPago)
         {
@@ -15,6 +15,5 @@ namespace Checkout.Payments.Request.Source.Apm
         public Payer Payer { get; set; }
 
         public string Description { get; set; }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestSepaSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestSepaSource.cs
@@ -2,13 +2,12 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestSepaSource : AbstractRequestSource
+    public class RequestSepaSource : AbstractRequestSource
     {
         public RequestSepaSource() : base(PaymentSourceType.Id)
         {
         }
 
         public string Id { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/Apm/RequestSofortSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/Apm/RequestSofortSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source.Apm
 {
-    public sealed class RequestSofortSource : AbstractRequestSource
+    public class RequestSofortSource : AbstractRequestSource
     {
         public RequestSofortSource() : base(PaymentSourceType.Sofort)
         {

--- a/src/CheckoutSdk/Payments/Request/Source/RequestCardSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestCardSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source
 {
-    public sealed class RequestCardSource : AbstractRequestSource
+    public class RequestCardSource : AbstractRequestSource
     {
         public RequestCardSource() : base(PaymentSourceType.Card)
         {

--- a/src/CheckoutSdk/Payments/Request/Source/RequestCustomerSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestCustomerSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source
 {
-    public sealed class RequestCustomerSource : AbstractRequestSource
+    public class RequestCustomerSource : AbstractRequestSource
     {
         public RequestCustomerSource() : base(PaymentSourceType.Customer)
         {

--- a/src/CheckoutSdk/Payments/Request/Source/RequestDLocalSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestDLocalSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source
 {
-    public sealed class RequestDLocalSource : AbstractRequestSource
+    public class RequestDLocalSource : AbstractRequestSource
     {
         public RequestDLocalSource() : base(PaymentSourceType.DLocal)
         {

--- a/src/CheckoutSdk/Payments/Request/Source/RequestIdSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestIdSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source
 {
-    public sealed class RequestIdSource : AbstractRequestSource
+    public class RequestIdSource : AbstractRequestSource
     {
         public RequestIdSource() : base(PaymentSourceType.Id)
         {

--- a/src/CheckoutSdk/Payments/Request/Source/RequestNetworkTokenSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestNetworkTokenSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source
 {
-    public sealed class RequestNetworkTokenSource : AbstractRequestSource
+    public class RequestNetworkTokenSource : AbstractRequestSource
     {
         public RequestNetworkTokenSource() : base(PaymentSourceType.NetworkToken)
         {

--- a/src/CheckoutSdk/Payments/Request/Source/RequestTokenSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestTokenSource.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Request.Source
 {
-    public sealed class RequestTokenSource : AbstractRequestSource
+    public class RequestTokenSource : AbstractRequestSource
     {
         public RequestTokenSource() : base(PaymentSourceType.Token)
         {

--- a/src/CheckoutSdk/Payments/Response/Destination/PaymentResponseCardDestination.cs
+++ b/src/CheckoutSdk/Payments/Response/Destination/PaymentResponseCardDestination.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments.Response.Destination
 {
-    public sealed class PaymentResponseCardDestination : AbstractPaymentResponseDestination,
+    public class PaymentResponseCardDestination : AbstractPaymentResponseDestination,
         IPaymentResponseDestination
     {
         public int? ExpiryMonth { get; set; }
@@ -33,6 +33,5 @@ namespace Checkout.Payments.Response.Destination
         {
             return base.Type;
         }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Response/GetPaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/Response/GetPaymentResponse.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments.Response
 {
-    public sealed class GetPaymentResponse : Resource
+    public class GetPaymentResponse : Resource
     {
         public string Id { get; set; }
 
@@ -55,6 +55,5 @@ namespace Checkout.Payments.Response
         public string SchemeId { get; set; }
 
         public IList<PaymentActionSummary> Actions { get; set; }
-             
     }
 }

--- a/src/CheckoutSdk/Payments/Response/PaymentResponse.cs
+++ b/src/CheckoutSdk/Payments/Response/PaymentResponse.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Checkout.Payments.Response
 {
-    public sealed class PaymentResponse : Resource
+    public class PaymentResponse : Resource
     {
         public string ActionId { get; set; }
 
@@ -44,6 +44,5 @@ namespace Checkout.Payments.Response
         public string Eci { get; set; }
 
         public string SchemeId { get; set; }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/Response/Source/ResponseCardSource.cs
+++ b/src/CheckoutSdk/Payments/Response/Source/ResponseCardSource.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Payments.Response.Source
 {
-    public sealed class ResponseCardSource : AbstractResponseSource, IResponseSource
+    public class ResponseCardSource : AbstractResponseSource, IResponseSource
     {
         public int? ExpiryMonth { get; set; }
 
@@ -44,6 +44,5 @@ namespace Checkout.Payments.Response.Source
         {
             return base.Type;
         }
-              
     }
 }

--- a/src/CheckoutSdk/Payments/RiskAssessment.cs
+++ b/src/CheckoutSdk/Payments/RiskAssessment.cs
@@ -1,8 +1,7 @@
 namespace Checkout.Payments
 {
-    public sealed class RiskAssessment 
+    public class RiskAssessment
     {
         public bool? Flagged { get; set; }
-      
     }
 }

--- a/src/CheckoutSdk/Payments/RiskRequest.cs
+++ b/src/CheckoutSdk/Payments/RiskRequest.cs
@@ -1,8 +1,7 @@
 namespace Checkout.Payments
 {
-    public sealed class RiskRequest
+    public class RiskRequest
     {
         public bool? Enabled { get; set; }
-     
     }
 }

--- a/src/CheckoutSdk/Payments/ShippingDetails.cs
+++ b/src/CheckoutSdk/Payments/ShippingDetails.cs
@@ -2,11 +2,10 @@ using Checkout.Common;
 
 namespace Checkout.Payments
 {
-    public sealed class ShippingDetails 
+    public class ShippingDetails
     {
         public Address Address { get; set; }
 
         public Phone Phone { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Payments/ThreeDSRequest.cs
+++ b/src/CheckoutSdk/Payments/ThreeDSRequest.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Payments
 {
-    public sealed class ThreeDsRequest 
+    public class ThreeDsRequest
     {
         public bool? Enabled { get; set; } = true;
 
@@ -18,6 +18,5 @@ namespace Checkout.Payments
         public string Version { get; set; }
 
         public Exemption? Exemption { get; set; }
-               
     }
 }

--- a/src/CheckoutSdk/Payments/ThreeDsData.cs
+++ b/src/CheckoutSdk/Payments/ThreeDsData.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Payments
 {
-    public sealed class ThreeDsData 
+    public class ThreeDsData 
     {
         public bool? Downgraded { get; set; }
 

--- a/src/CheckoutSdk/Payments/ThreeDsEnrollment.cs
+++ b/src/CheckoutSdk/Payments/ThreeDsEnrollment.cs
@@ -2,11 +2,10 @@ using Checkout.Common;
 
 namespace Checkout.Payments
 {
-    public sealed class ThreeDsEnrollment
+    public class ThreeDsEnrollment
     {
         public bool? Downgraded { get; set; }
 
         public ThreeDsEnrollmentStatus? Enrolled { get; set; }
-       
     }
 }

--- a/src/CheckoutSdk/Payments/Util/PaymentResponseDestinationTypeConverter.cs
+++ b/src/CheckoutSdk/Payments/Util/PaymentResponseDestinationTypeConverter.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 
 namespace Checkout.Payments.Util
 {
-    public sealed class PaymentResponseDestinationTypeConverter : JsonConverter
+    public class PaymentResponseDestinationTypeConverter : JsonConverter
     {
         public override bool CanWrite => false;
 

--- a/src/CheckoutSdk/Payments/Util/PaymentResponseSourceTypeConverter.cs
+++ b/src/CheckoutSdk/Payments/Util/PaymentResponseSourceTypeConverter.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 namespace Checkout.Payments.Util
 {
-    public sealed class PaymentResponseSourceTypeConverter : JsonConverter
+    public class PaymentResponseSourceTypeConverter : JsonConverter
     {
         public override bool CanWrite => false;
 

--- a/src/CheckoutSdk/Payments/VoidRequest.cs
+++ b/src/CheckoutSdk/Payments/VoidRequest.cs
@@ -2,11 +2,10 @@ using System.Collections.Generic;
 
 namespace Checkout.Payments
 {
-    public sealed class VoidRequest 
+    public class VoidRequest
     {
         public string Reference { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
-               
     }
 }

--- a/src/CheckoutSdk/Payments/VoidResponse.cs
+++ b/src/CheckoutSdk/Payments/VoidResponse.cs
@@ -2,11 +2,10 @@ using Checkout.Common;
 
 namespace Checkout.Payments
 {
-    public sealed class VoidResponse : Resource
+    public class VoidResponse : Resource
     {
         public string ActionId { get; set; }
 
         public string Reference { get; set; }
-
     }
 }

--- a/src/CheckoutSdk/Reconciliation/Action.cs
+++ b/src/CheckoutSdk/Reconciliation/Action.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Reconciliation
 {
-    public sealed class Action
+    public class Action
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Reconciliation/Breakdown.cs
+++ b/src/CheckoutSdk/Reconciliation/Breakdown.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Reconciliation
 {
-    public sealed class Breakdown
+    public class Breakdown
     {
         public string Type { get; set; }
 

--- a/src/CheckoutSdk/Reconciliation/PaymentReportData.cs
+++ b/src/CheckoutSdk/Reconciliation/PaymentReportData.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Reconciliation
 {
-    public sealed class PaymentReportData : Resource
+    public class PaymentReportData : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Reconciliation/PayoutStatement.cs
+++ b/src/CheckoutSdk/Reconciliation/PayoutStatement.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Reconciliation
 {
-    public sealed class PayoutStatement : Resource
+    public class PayoutStatement : Resource
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Reconciliation/ReconciliationPaymentReportResponse.cs
+++ b/src/CheckoutSdk/Reconciliation/ReconciliationPaymentReportResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Reconciliation
 {
-    public sealed class ReconciliationPaymentReportResponse : Resource
+    public class ReconciliationPaymentReportResponse : Resource
     {
         public int? Count { get; set; }
 

--- a/src/CheckoutSdk/Reconciliation/ReconciliationQueryPaymentsFilter.cs
+++ b/src/CheckoutSdk/Reconciliation/ReconciliationQueryPaymentsFilter.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Reconciliation
 {
-    public sealed class ReconciliationQueryPaymentsFilter
+    public class ReconciliationQueryPaymentsFilter
     {
         public int Limit { get; set; } = 500;
 

--- a/src/CheckoutSdk/Reconciliation/StatementData.cs
+++ b/src/CheckoutSdk/Reconciliation/StatementData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Reconciliation
 {
-    public sealed class StatementData
+    public class StatementData
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Reconciliation/StatementReportResponse.cs
+++ b/src/CheckoutSdk/Reconciliation/StatementReportResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Reconciliation
 {
-    public sealed class StatementReportResponse : Resource
+    public class StatementReportResponse : Resource
     {
         public int? Count { get; set; }
 

--- a/src/CheckoutSdk/Risk/Device.cs
+++ b/src/CheckoutSdk/Risk/Device.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Checkout.Risk
 {
-    public sealed class Device
+    public class Device
     {
         public string Ip { get; set; }
 

--- a/src/CheckoutSdk/Risk/Location.cs
+++ b/src/CheckoutSdk/Risk/Location.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Risk
 {
-    public sealed class Location
+    public class Location
     {
         public string Latitude { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationAssessmentRequest.cs
+++ b/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationAssessmentRequest.cs
@@ -5,7 +5,7 @@ using System.Collections;
 
 namespace Checkout.Risk.PreAuthentication
 {
-    public sealed class PreAuthenticationAssessmentRequest
+    public class PreAuthenticationAssessmentRequest
     {
         public DateTime? Date { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationAssessmentResponse.cs
+++ b/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationAssessmentResponse.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Risk.PreAuthentication
 {
-    public sealed class PreAuthenticationAssessmentResponse : Resource
+    public class PreAuthenticationAssessmentResponse : Resource
     {
         public string AssessmentId { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationResult.cs
+++ b/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationResult.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Risk.PreAuthentication
 {
-    public sealed class PreAuthenticationResult
+    public class PreAuthenticationResult
     {
         public PreAuthenticationDecision? Decision { get; set; }
     }

--- a/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationWarning.cs
+++ b/src/CheckoutSdk/Risk/PreAuthentication/PreAuthenticationWarning.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Risk.PreAuthentication
 {
-    public sealed class PreAuthenticationWarning
+    public class PreAuthenticationWarning
     {
         public PreAuthenticationDecision? Decision { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreCapture/AuthenticationResult.cs
+++ b/src/CheckoutSdk/Risk/PreCapture/AuthenticationResult.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Risk.PreCapture
 {
-    public sealed class AuthenticationResult
+    public class AuthenticationResult
     {
         public bool? Attempted { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreCapture/AuthorizationResult.cs
+++ b/src/CheckoutSdk/Risk/PreCapture/AuthorizationResult.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Risk.PreCapture
 {
-    public sealed class AuthorizationResult
+    public class AuthorizationResult
     {
         public string AvsCode { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreCapture/PreCaptureAssessmentRequest.cs
+++ b/src/CheckoutSdk/Risk/PreCapture/PreCaptureAssessmentRequest.cs
@@ -5,7 +5,7 @@ using System.Collections;
 
 namespace Checkout.Risk.PreCapture
 {
-    public sealed class PreCaptureAssessmentRequest
+    public class PreCaptureAssessmentRequest
     {
         public string AssessmentId { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreCapture/PreCaptureAssessmentResponse.cs
+++ b/src/CheckoutSdk/Risk/PreCapture/PreCaptureAssessmentResponse.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Risk.PreCapture
 {
-    public sealed class PreCaptureAssessmentResponse : Resource
+    public class PreCaptureAssessmentResponse : Resource
     {
         public string AssessmentId { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreCapture/PreCaptureResult.cs
+++ b/src/CheckoutSdk/Risk/PreCapture/PreCaptureResult.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Risk.PreCapture
 {
-    public sealed class PreCaptureResult
+    public class PreCaptureResult
     {
         public PreCaptureDecision? Decision { get; set; }
 

--- a/src/CheckoutSdk/Risk/PreCapture/PreCaptureWarning.cs
+++ b/src/CheckoutSdk/Risk/PreCapture/PreCaptureWarning.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Risk.PreCapture
 {
-    public sealed class PreCaptureWarning
+    public class PreCaptureWarning
     {
         public PreCaptureDecision? Decision { get; set; }
 

--- a/src/CheckoutSdk/Risk/RiskPayment.cs
+++ b/src/CheckoutSdk/Risk/RiskPayment.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Risk
 {
-    public sealed class RiskPayment
+    public class RiskPayment
     {
         public string Psp { get; set; }
 

--- a/src/CheckoutSdk/Risk/RiskShippingDetails.cs
+++ b/src/CheckoutSdk/Risk/RiskShippingDetails.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Risk
 {
-    public sealed class RiskShippingDetails
+    public class RiskShippingDetails
     {
         public Address Address { get; set; }
     }

--- a/src/CheckoutSdk/Risk/source/CardSourcePrism.cs
+++ b/src/CheckoutSdk/Risk/source/CardSourcePrism.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Risk.source
 {
-    public sealed class CardSourcePrism : RiskPaymentRequestSource
+    public class CardSourcePrism : RiskPaymentRequestSource
     {
         public CardSourcePrism() : base(PaymentSourceType.Card)
         {

--- a/src/CheckoutSdk/Risk/source/CustomerSourcePrism.cs
+++ b/src/CheckoutSdk/Risk/source/CustomerSourcePrism.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Risk.source
 {
-    public sealed class CustomerSourcePrism : RiskPaymentRequestSource
+    public class CustomerSourcePrism : RiskPaymentRequestSource
     {
         public CustomerSourcePrism() : base(PaymentSourceType.Customer)
         {

--- a/src/CheckoutSdk/Risk/source/IdSourcePrism.cs
+++ b/src/CheckoutSdk/Risk/source/IdSourcePrism.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Risk.source
 {
-    public sealed class IdSourcePrism : RiskPaymentRequestSource
+    public class IdSourcePrism : RiskPaymentRequestSource
     {
         public IdSourcePrism() : base(PaymentSourceType.Id)
         {

--- a/src/CheckoutSdk/Sources/SepaSourceRequest.cs
+++ b/src/CheckoutSdk/Sources/SepaSourceRequest.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Sources
 {
-    public sealed class SepaSourceRequest : SourceRequest
+    public class SepaSourceRequest : SourceRequest
     {
         public SepaSourceRequest() : base(SourceType.Sepa)
         {

--- a/src/CheckoutSdk/Sources/SepaSourceResponse.cs
+++ b/src/CheckoutSdk/Sources/SepaSourceResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Sources
 {
-    public sealed class SepaSourceResponse : SourceResponse
+    public class SepaSourceResponse : SourceResponse
     {
         public ResponseData ResponseData { get; set; }
     }

--- a/src/CheckoutSdk/Sources/SourceData.cs
+++ b/src/CheckoutSdk/Sources/SourceData.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Sources
 {
-    public sealed class SourceData
+    public class SourceData
     {
         public string FirstName { get; set; }
 

--- a/src/CheckoutSdk/Tokens/ApplePayTokenData.cs
+++ b/src/CheckoutSdk/Tokens/ApplePayTokenData.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Tokens
 {
-    public sealed class ApplePayTokenData
+    public class ApplePayTokenData
     {
         public string Version { get; set; }
 

--- a/src/CheckoutSdk/Tokens/ApplePayTokenRequest.cs
+++ b/src/CheckoutSdk/Tokens/ApplePayTokenRequest.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Checkout.Tokens
 {
-    public sealed class ApplePayTokenRequest : WalletTokenRequest
+    public class ApplePayTokenRequest : WalletTokenRequest
     {
         public ApplePayTokenRequest() : base(TokenType.ApplePay)
         {

--- a/src/CheckoutSdk/Tokens/CardTokenRequest.cs
+++ b/src/CheckoutSdk/Tokens/CardTokenRequest.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Tokens
 {
-    public sealed class CardTokenRequest
+    public class CardTokenRequest
     {
         public readonly TokenType Type = TokenType.Card;
 

--- a/src/CheckoutSdk/Tokens/CardTokenResponse.cs
+++ b/src/CheckoutSdk/Tokens/CardTokenResponse.cs
@@ -2,7 +2,7 @@ using Checkout.Common;
 
 namespace Checkout.Tokens
 {
-    public sealed class CardTokenResponse : TokenResponse
+    public class CardTokenResponse : TokenResponse
     {
         public Address BillingAddress { get; set; }
 

--- a/src/CheckoutSdk/Tokens/GooglePayTokenData.cs
+++ b/src/CheckoutSdk/Tokens/GooglePayTokenData.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Tokens
 {
-    public sealed class GooglePayTokenData
+    public class GooglePayTokenData
     {
         public string Signature { get; set; }
 

--- a/src/CheckoutSdk/Tokens/GooglePayTokenRequest.cs
+++ b/src/CheckoutSdk/Tokens/GooglePayTokenRequest.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Checkout.Tokens
 {
-    public sealed class GooglePayTokenRequest : WalletTokenRequest
+    public class GooglePayTokenRequest : WalletTokenRequest
     {
         public GooglePayTokenRequest() : base(TokenType.GooglePay)
         {

--- a/src/CheckoutSdk/Webhooks/WebhookRequest.cs
+++ b/src/CheckoutSdk/Webhooks/WebhookRequest.cs
@@ -1,9 +1,8 @@
-using System;
 using System.Collections.Generic;
 
 namespace Checkout.Webhooks
 {
-    public sealed class WebhookRequest 
+    public class WebhookRequest
     {
         public string Url { get; set; }
 
@@ -14,6 +13,5 @@ namespace Checkout.Webhooks
         public WebhookContentType? ContentType { get; set; }
 
         public IList<string> EventTypes { get; set; }
-      
     }
 }

--- a/src/CheckoutSdk/Webhooks/WebhookResponse.cs
+++ b/src/CheckoutSdk/Webhooks/WebhookResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Webhooks
 {
-    public sealed class WebhookResponse : Resource
+    public class WebhookResponse : Resource
     {
         public string Id { get; set; }
 
@@ -16,6 +16,5 @@ namespace Checkout.Webhooks
         public WebhookContentType? ContentType { get; set; }
 
         public IList<string> EventTypes { get; set; }
-      
     }
 }


### PR DESCRIPTION
This commit makes model request/response and related classes inheritable by removing the `sealed` modifier. Internal classes, exceptions and any other class that need to meet serialization standards was not modified.