### PR TITLE
Optimize integration testing

### DIFF
--- a/test/CheckoutSdkTest/Apm/Ideal/IdealIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Apm/Ideal/IdealIntegrationTest.cs
@@ -1,5 +1,5 @@
-using System.Threading.Tasks;
 using Shouldly;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Apm.Ideal
@@ -10,7 +10,7 @@ namespace Checkout.Apm.Ideal
         {
         }
 
-        [Fact(Skip = "unstable")]
+        [Fact(Skip = "unavailable")]
         private async Task ShouldGetInfo()
         {
             var idealInfo = await DefaultApi.IdealClient().GetInfo();

--- a/test/CheckoutSdkTest/Customers/Four/CustomersIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Customers/Four/CustomersIntegrationTest.cs
@@ -1,6 +1,6 @@
-using System.Threading.Tasks;
 using Checkout.Common;
 using Shouldly;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Customers.Four
@@ -18,11 +18,7 @@ namespace Checkout.Customers.Four
             {
                 Email = GenerateRandomEmail(),
                 Name = "Customer",
-                Phone = new Phone
-                {
-                    CountryCode = "1",
-                    Number = "4155552671"
-                }
+                Phone = new Phone {CountryCode = "1", Number = "4155552671"}
             };
             var customerResponse = await FourApi.CustomersClient().Create(request);
             customerResponse.ShouldNotBeNull();
@@ -31,7 +27,7 @@ namespace Checkout.Customers.Four
             customerDetails.ShouldNotBeNull();
             customerDetails.Email.ShouldBe(request.Email);
             customerDetails.Name.ShouldBe(request.Name);
-            customerDetails.Phone.ShouldNotBeNull(); 
+            customerDetails.Phone.ShouldNotBeNull();
             customerDetails.DefaultId.ShouldBeNull();
             customerDetails.Instruments.ShouldBeEmpty();
         }
@@ -44,11 +40,7 @@ namespace Checkout.Customers.Four
             {
                 Email = GenerateRandomEmail(),
                 Name = "Customer",
-                Phone = new Phone
-                {
-                    CountryCode = "1",
-                    Number = "4155552671"
-                }
+                Phone = new Phone {CountryCode = "1", Number = "4155552671"}
             };
             var customerResponse = await FourApi.CustomersClient().Create(request);
             customerResponse.ShouldNotBeNull();
@@ -72,19 +64,13 @@ namespace Checkout.Customers.Four
             {
                 Email = GenerateRandomEmail(),
                 Name = "Customer",
-                Phone = new Phone
-                {
-                    CountryCode = "1",
-                    Number = "4155552671"
-                }
+                Phone = new Phone {CountryCode = "1", Number = "4155552671"}
             };
             var customerResponse = await FourApi.CustomersClient().Create(request);
             customerResponse.ShouldNotBeNull();
 
             var customerId = customerResponse.Id;
             await FourApi.CustomersClient().Delete(customerId);
-
-            await Nap();
 
             await AssertNotFound(FourApi.CustomersClient().Get(customerId));
         }

--- a/test/CheckoutSdkTest/Events/EventsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Events/EventsIntegrationTest.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Checkout.Payments;
 using Checkout.Webhooks;
 using Shouldly;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Events
@@ -59,18 +59,11 @@ namespace Checkout.Events
             payment.ShouldNotBeNull();
 
 
-            var retrieveEventsRequest = new RetrieveEventsRequest()
-            {
-                PaymentId = payment.Id
-            };
+            var retrieveEventsRequest = new RetrieveEventsRequest {PaymentId = payment.Id};
 
             //Retrieve events
-            EventsPageResponse events = null;
-            while (events == null)
-            {
-                await Nap();
-                events = await DefaultApi.EventsClient().RetrieveEvents(retrieveEventsRequest);
-            }
+            EventsPageResponse events = await Retriable(async () =>
+                await DefaultApi.EventsClient().RetrieveEvents(retrieveEventsRequest));
 
             events.ShouldNotBeNull();
             events.TotalCount.ShouldBe(1);

--- a/test/CheckoutSdkTest/Payments/CapturePaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/CapturePaymentsIntegrationTest.cs
@@ -16,14 +16,15 @@ namespace Checkout.Payments
 
             captureRequest.Metadata.Add("CapturePaymentsIntegrationTest", "ShouldFullCaptureCardPayment");
 
-            var response = await DefaultApi.PaymentsClient().CapturePayment(paymentResponse.Id, captureRequest);
+            var response = await Retriable(async () =>
+                await DefaultApi.PaymentsClient().CapturePayment(paymentResponse.Id, captureRequest));
 
             response.ShouldNotBeNull();
             response.Reference.ShouldNotBeNullOrEmpty();
             response.ActionId.ShouldNotBeNullOrEmpty();
         }
 
-        [Fact(Skip = "unstable")]
+        [Fact]
         private async Task ShouldPartiallyCaptureCardPayment()
         {
             var paymentResponse = await MakeCardPayment();
@@ -32,7 +33,8 @@ namespace Checkout.Payments
 
             captureRequest.Metadata.Add("CapturePaymentsIntegrationTest", "ShouldFullCaptureCardPayment");
 
-            var response = await DefaultApi.PaymentsClient().CapturePayment(paymentResponse.Id, captureRequest);
+            var response = await Retriable(async () =>
+                await DefaultApi.PaymentsClient().CapturePayment(paymentResponse.Id, captureRequest));
 
             response.ShouldNotBeNull();
             response.Reference.ShouldNotBeNullOrEmpty();

--- a/test/CheckoutSdkTest/Payments/Four/RefundPaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Four/RefundPaymentsIntegrationTest.cs
@@ -1,6 +1,6 @@
+using Shouldly;
 using System;
 using System.Threading.Tasks;
-using Shouldly;
 using Xunit;
 
 namespace Checkout.Payments.Four
@@ -12,24 +12,21 @@ namespace Checkout.Payments.Four
         {
             var paymentResponse = await MakeCardPayment(true);
 
-            await Nap();
-
             var refundRequest = new RefundRequest
             {
-                Reference = Guid.NewGuid().ToString(),
-                Amount = paymentResponse.Amount
+                Reference = Guid.NewGuid().ToString(), Amount = paymentResponse.Amount
             };
 
-            var response = await FourApi.PaymentsClient().RefundPayment(paymentResponse.Id, refundRequest);
+            var response = await Retriable(async () =>
+                await FourApi.PaymentsClient().RefundPayment(paymentResponse.Id, refundRequest));
 
             response.ShouldNotBeNull();
             response.ActionId.ShouldNotBeNullOrEmpty();
             response.Reference.ShouldNotBeNullOrEmpty();
             response.GetLink("payment").ShouldNotBeNull();
 
-            await Nap();
-
-            var payment = await FourApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id);
+            var payment = await Retriable(async () =>
+                await FourApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id));
             //Balances
             payment.Balances.TotalAuthorized.ShouldBe(paymentResponse.Amount);
             payment.Balances.TotalCaptured.ShouldBe(paymentResponse.Amount);
@@ -45,24 +42,21 @@ namespace Checkout.Payments.Four
         {
             var paymentResponse = await MakeCardPayment(true);
 
-            await Nap();
-
             var refundRequest = new RefundRequest
             {
-                Reference = Guid.NewGuid().ToString(),
-                Amount = paymentResponse.Amount / 2
+                Reference = Guid.NewGuid().ToString(), Amount = paymentResponse.Amount / 2
             };
 
-            var response = await FourApi.PaymentsClient().RefundPayment(paymentResponse.Id, refundRequest);
+            var response = await Retriable(async () =>
+                await FourApi.PaymentsClient().RefundPayment(paymentResponse.Id, refundRequest));
 
             response.ShouldNotBeNull();
             response.ActionId.ShouldNotBeNullOrEmpty();
             response.Reference.ShouldNotBeNullOrEmpty();
             response.GetLink("payment").ShouldNotBeNull();
 
-            await Nap();
-
-            var payment = await FourApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id);
+            var payment = await Retriable(async () =>
+                await FourApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id));
             //Balances
             payment.Balances.TotalAuthorized.ShouldBe(paymentResponse.Amount);
             payment.Balances.TotalCaptured.ShouldBe(paymentResponse.Amount);

--- a/test/CheckoutSdkTest/Payments/GetPaymentDetailsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/GetPaymentDetailsIntegrationTest.cs
@@ -13,9 +13,8 @@ namespace Checkout.Payments
         {
             var paymentResponse = await MakeCardPayment(true);
 
-            await Nap();
-
-            var payment = await DefaultApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id);
+            var payment = await Retriable(async () =>
+                await DefaultApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id));
 
             payment.Id.ShouldNotBeNullOrEmpty();
             payment.PaymentType.ShouldBe(PaymentType.Regular);

--- a/test/CheckoutSdkTest/Payments/RequestPayoutsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/RequestPayoutsIntegrationTest.cs
@@ -64,9 +64,8 @@ namespace Checkout.Payments
             paymentResponse.HasLink("capture").ShouldBeFalse();
             paymentResponse.HasLink("void").ShouldBeFalse();
 
-            await Nap();
-
-            var payment = await DefaultApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id);
+            var payment = await Retriable(async () =>
+                await DefaultApi.PaymentsClient().GetPaymentDetails(paymentResponse.Id));
             payment.ShouldNotBeNull();
 
             // Destination

--- a/test/CheckoutSdkTest/Workflows/Four/AbstractWorkflowIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Workflows/Four/AbstractWorkflowIntegrationTest.cs
@@ -140,14 +140,6 @@ namespace Checkout.Workflows.Four
             return paymentResponse;
         }
 
-        protected async Task CapturePayment(string paymentId)
-        {
-            var response = await FourApi.PaymentsClient().CapturePayment(paymentId, null);
-
-            response.ShouldNotBeNull();
-            response.ActionId.ShouldNotBeNullOrEmpty();
-        }
-
         protected async Task<SubjectEvent> GetSubjectEvent(string subjectId)
         {
             SubjectEventsResponse subjectEventsResponse = await FourApi.WorkflowsClient().GetSubjectEvents(subjectId);

--- a/test/CheckoutSdkTest/Workflows/Four/WorkflowsReflowIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Workflows/Four/WorkflowsReflowIntegrationTest.cs
@@ -10,16 +10,14 @@ namespace Checkout.Workflows.Four
 {
     public class WorkflowsReflowIntegrationTest : AbstractWorkflowIntegrationTest
     {
-        [Fact(Skip = "unstable")]
+        [Fact]
         public async Task ShouldReflowByEvent()
         {
             await CreateWorkflow();
 
             PaymentResponse payment = await MakeCardPayment();
 
-            await Nap(10);
-
-            SubjectEvent paymentApprovedEvent = await GetSubjectEvent(payment.Id);
+            SubjectEvent paymentApprovedEvent = await Retriable(async () => await GetSubjectEvent(payment.Id));
 
             paymentApprovedEvent.ShouldNotBeNull();
             paymentApprovedEvent.Id.ShouldNotBeNullOrEmpty();
@@ -29,62 +27,55 @@ namespace Checkout.Workflows.Four
             reflowResponse.ShouldBeNull();
         }
 
-        [Fact(Timeout = 180000, Skip = "unstable")]
+        [Fact]
         public async Task ShouldReflowBySubject()
         {
             await CreateWorkflow();
 
             PaymentResponse payment = await MakeCardPayment();
 
-            await Nap(10);
-
-            ReflowResponse reflowResponse = await FourApi.WorkflowsClient().ReflowBySubject(payment.Id);
+            ReflowResponse reflowResponse =
+                await Retriable(async () => await FourApi.WorkflowsClient().ReflowBySubject(payment.Id));
 
             reflowResponse.ShouldBeNull();
         }
 
-        [Fact(Timeout = 180000, Skip = "unstable")]
+        [Fact]
         public async Task ShouldReflowByEventAndWorkflow()
         {
             CreateWorkflowResponse createWorkflowResponse = await CreateWorkflow();
 
             PaymentResponse payment = await MakeCardPayment();
 
-            await Nap(10);
+            SubjectEvent paymentApprovedEvent = await Retriable(async () => await GetSubjectEvent(payment.Id));
 
-            SubjectEvent paymentApprovedEvent = await GetSubjectEvent(payment.Id);
-
-            ReflowResponse reflowResponse = await FourApi.WorkflowsClient()
-                .ReflowByEventAndWorkflow(paymentApprovedEvent.Id, createWorkflowResponse.Id);
+            ReflowResponse reflowResponse = await Retriable(async () => await FourApi.WorkflowsClient()
+                .ReflowByEventAndWorkflow(paymentApprovedEvent.Id, createWorkflowResponse.Id));
 
             reflowResponse.ShouldBeNull();
         }
 
-        [Fact(Timeout = 180000, Skip = "unstable")]
+        [Fact]
         public async Task ShouldReflowBySubjectAndWorkflow()
         {
             CreateWorkflowResponse createWorkflowResponse = await CreateWorkflow();
 
             PaymentResponse payment = await MakeCardPayment();
 
-            await Nap(10);
-
-            ReflowResponse reflowResponse = await FourApi.WorkflowsClient()
-                .ReflowBySubjectAndWorkflow(payment.Id, createWorkflowResponse.Id);
+            ReflowResponse reflowResponse = await Retriable(async () => await FourApi.WorkflowsClient()
+                .ReflowBySubjectAndWorkflow(payment.Id, createWorkflowResponse.Id));
 
             reflowResponse.ShouldBeNull();
         }
 
-        [Fact(Skip = "unstable")]
+        [Fact]
         public async Task ShouldReflowByEvents()
         {
             CreateWorkflowResponse createWorkflowResponse = await CreateWorkflow();
 
             PaymentResponse payment = await MakeCardPayment();
 
-            await Nap(10);
-
-            SubjectEvent paymentApprovedEvent = await GetSubjectEvent(payment.Id);
+            SubjectEvent paymentApprovedEvent = await Retriable(async () => await GetSubjectEvent(payment.Id));
 
             ReflowByEventsRequest request = new ReflowByEventsRequest
             {
@@ -104,14 +95,13 @@ namespace Checkout.Workflows.Four
 
             PaymentResponse payment = await MakeCardPayment();
 
-            await Nap(10);
-
             ReflowBySubjectsRequest request = new ReflowBySubjectsRequest
             {
                 Subjects = new List<string> {payment.Id}, Workflows = new List<string> {createWorkflowResponse.Id}
             };
 
-            ReflowResponse reflowResponse = await FourApi.WorkflowsClient().Reflow(request);
+            ReflowResponse reflowResponse =
+                await Retriable(async () => await FourApi.WorkflowsClient().Reflow(request));
 
             reflowResponse.ShouldBeNull();
         }


### PR DESCRIPTION
This commit optimizes the execution of the existing integration testing suite by replacing `wait` operations by `Retriable` - a retry mechanism tha retries failed requests and can be configured to respect certain conditions. Disable tests marked as "unstable" were re-enabled.