### PR TITLE
Downgrade `Microsoft.Extensions.*` to 3.1.22

### DIFF
--- a/src/CheckoutSdk.Extensions/CheckoutSdk.Extensions.csproj
+++ b/src/CheckoutSdk.Extensions/CheckoutSdk.Extensions.csproj
@@ -20,9 +20,9 @@
       <ProjectReference Include="..\CheckoutSdk\CheckoutSdk.csproj" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.22" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.22" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
     </ItemGroup>
 
 </Project>

--- a/src/CheckoutSdk/CheckoutSdk.csproj
+++ b/src/CheckoutSdk/CheckoutSdk.csproj
@@ -25,7 +25,7 @@
     <ItemGroup Label="Package References">
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.22" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 


### PR DESCRIPTION
This commit downgrades `Microsoft.Extensions.*` from version 5.0.0 to 3.1.22 to avoid transitive dependency to `net5.0`.