### PR TITLE
Retargeted to allow referencing of multiple versions of Microsoft.Ext…

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -20,6 +20,7 @@ jobs:
             2.0.x
             3.1.x
             5.0.x
+            6.0.x            
       - id: list-installed-runtimes
         run: dotnet --list-runtimes
       - id: cache-sonarcloud-packages

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -20,6 +20,7 @@ jobs:
             2.0.x
             3.1.x
             5.0.x
+            6.0.x
       - id: list-installed-runtimes
         run: dotnet --list-runtimes
       - id: cache-sonarcloud-packages

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,6 +16,7 @@ jobs:
             2.0.x
             3.1.x
             5.0.x
+            6.0.x
       - id: list-installed-runtimes
         run: dotnet --list-runtimes
       - id: build-solution

--- a/src/CheckoutSdk.Extensions/CheckoutSdk.Extensions.csproj
+++ b/src/CheckoutSdk.Extensions/CheckoutSdk.Extensions.csproj
@@ -1,28 +1,35 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <PackageId>CheckoutSDK.Extensions.Microsoft</PackageId>
-        <Title>Checkout.com SDK Extension</Title>
-        <Description>Checkout.com Extension for Microsoft Configuration and Dependency Injection</Description>
-        <AssemblyTitle>CheckoutSDK.Extensions</AssemblyTitle>
-        <NeutralLanguage>en-GB</NeutralLanguage>
-        <Authors>Checkout.com</Authors>
-        <Copyright>Checkout.com</Copyright>
-        <PackageProjectUrl>https://github.com/checkout/checkout-sdk-net</PackageProjectUrl>
-        <License>https://github.com/checkout/checkout-sdk-net/raw/master/LICENSE.md</License>
-        <Icon>https://raw.githubusercontent.com/checkout/checkout-sdk-net/master/assets/checkout-icon.png</Icon>
-        <PackageTags>Checkout.com;payments;gateway;sdk</PackageTags>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>git://github.com/checkout/checkout-sdk-net</RepositoryUrl>
-        <TargetFrameworks>net5.0;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <RootNamespace>CheckoutSDK.Extensions.Configuration</RootNamespace>
-    </PropertyGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\CheckoutSdk\CheckoutSdk.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.22" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.22" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
-    </ItemGroup>
+  <PropertyGroup>
+    <PackageId>CheckoutSDK.Extensions.Microsoft</PackageId>
+    <Title>Checkout.com SDK Extension</Title>
+    <Description>Checkout.com Extension for Microsoft Configuration and Dependency Injection</Description>
+    <AssemblyTitle>CheckoutSDK.Extensions</AssemblyTitle>
+    <NeutralLanguage>en-GB</NeutralLanguage>
+    <Authors>Checkout.com</Authors>
+    <Copyright>Checkout.com</Copyright>
+    <PackageProjectUrl>https://github.com/checkout/checkout-sdk-net</PackageProjectUrl>
+    <License>https://github.com/checkout/checkout-sdk-net/raw/master/LICENSE.md</License>
+    <Icon>https://raw.githubusercontent.com/checkout/checkout-sdk-net/master/assets/checkout-icon.png</Icon>
+    <PackageTags>Checkout.com;payments;gateway;sdk</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/checkout/checkout-sdk-net</RepositoryUrl>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.0</TargetFrameworks>
+    <RootNamespace>CheckoutSDK.Extensions.Configuration</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CheckoutSdk\CheckoutSdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.22" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.22" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/CheckoutSdk/CheckoutSdk.csproj
+++ b/src/CheckoutSdk/CheckoutSdk.csproj
@@ -1,38 +1,45 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <PackageId>CheckoutSDK</PackageId>
-        <Title>Checkout.com SDK</Title>
-        <Description>
-            Checkout.com SDK for .NET
-        </Description>
-        <AssemblyTitle>CheckoutSdk</AssemblyTitle>
-        <NeutralLanguage>en-GB</NeutralLanguage>
-        <Authors>Checkout.com</Authors>
-        <Copyright>Checkout.com</Copyright>
-        <AssemblyName>CheckoutSdk</AssemblyName>
-        <PackageProjectUrl>https://github.com/checkout/checkout-sdk-net</PackageProjectUrl>
-        <License>https://github.com/checkout/checkout-sdk-net/raw/master/LICENSE.md</License>
-        <Icon>https://raw.githubusercontent.com/checkout/checkout-sdk-net/develop/assets/checkout-icon.png</Icon>
-        <PackageTags>Checkout.com;payments;gateway;sdk</PackageTags>
-        <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>git://github.com/checkout/checkout-sdk-net</RepositoryUrl>
-        <TargetFrameworks>net5.0;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <RootNamespace>Checkout</RootNamespace>
-        <PackageReleaseNotes>
-        </PackageReleaseNotes>
-    </PropertyGroup>
-    
-    <ItemGroup Label="Package References">
-        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.22" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    </ItemGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageId>CheckoutSDK</PackageId>
+    <Title>Checkout.com SDK</Title>
+    <Description>
+      Checkout.com SDK for .NET
+    </Description>
+    <AssemblyTitle>CheckoutSdk</AssemblyTitle>
+    <NeutralLanguage>en-GB</NeutralLanguage>
+    <Authors>Checkout.com</Authors>
+    <Copyright>Checkout.com</Copyright>
+    <AssemblyName>CheckoutSdk</AssemblyName>
+    <PackageProjectUrl>https://github.com/checkout/checkout-sdk-net</PackageProjectUrl>
+    <License>https://github.com/checkout/checkout-sdk-net/raw/master/LICENSE.md</License>
+    <Icon>https://raw.githubusercontent.com/checkout/checkout-sdk-net/develop/assets/checkout-icon.png</Icon>
+    <PackageTags>Checkout.com;payments;gateway;sdk</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/checkout/checkout-sdk-net</RepositoryUrl>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.0</TargetFrameworks>
+    <RootNamespace>Checkout</RootNamespace>
+    <PackageReleaseNotes>
+    </PackageReleaseNotes>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>CheckoutSdkTest</_Parameter1>
-        </AssemblyAttribute>
-    </ItemGroup>
+  <ItemGroup Label="Global Package References">
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Label="NET Standard Package References"  Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.22" />
+  </ItemGroup>
+
+  <ItemGroup Label="NET 5 Package References"  Condition=" '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>CheckoutSdkTest</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 </Project>

--- a/test/CheckoutSdkTest/CheckoutSdkTest.csproj
+++ b/test/CheckoutSdkTest/CheckoutSdkTest.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <RootNamespace>Checkout</RootNamespace>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
…ensions* packages. This PR allows usage of the library in azure functions v1-5 by retargeting the projects to .net6, .net 5, where versions 6+ of the Microsoft.Extensions* libraries are referenced, as well as targeting the .NETSTANDARD 2.0 where v3.1.17 of the Microsoft.Extensions* libraries are referenced.