### PR TITLE
Adding missing reconciliation operations

### DIFF
--- a/src/CheckoutSdk/Disputes/DisputesClient.cs
+++ b/src/CheckoutSdk/Disputes/DisputesClient.cs
@@ -20,7 +20,8 @@ namespace Checkout.Disputes
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("filter", filter);
-            return ApiClient.Query<DisputesQueryResponse>(DisputesPath, SdkAuthorization(), filter, cancellationToken);
+            return ApiClient.Query<DisputesQueryResponse>(DisputesPath, SdkAuthorization(), filter,
+                cancellationToken);
         }
 
         public Task<DisputeDetailsResponse> GetDisputeDetails(string disputeId,

--- a/src/CheckoutSdk/Disputes/Four/DisputesClient.cs
+++ b/src/CheckoutSdk/Disputes/Four/DisputesClient.cs
@@ -16,7 +16,8 @@ namespace Checkout.Disputes.Four
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("filter", filter);
-            return ApiClient.Query<DisputesQueryResponse>(DisputesPath, SdkAuthorization(), filter, cancellationToken);
+            return ApiClient.Query<DisputesQueryResponse>(DisputesPath, SdkAuthorization(), filter,
+                cancellationToken);
         }
 
         public new Task<DisputeDetailsResponse> GetDisputeDetails(string disputeId,

--- a/src/CheckoutSdk/Instruments/Four/InstrumentsClient.cs
+++ b/src/CheckoutSdk/Instruments/Four/InstrumentsClient.cs
@@ -57,8 +57,10 @@ namespace Checkout.Instruments.Four
         public Task<BankAccountFieldResponse> GetBankAccountFieldFormatting(CountryCode country, Currency currency,
             BankAccountFieldQuery bankAccountFieldQuery, CancellationToken cancellationToken = default)
         {
-            CheckoutUtils.ValidateParams("country", country, "currency", currency, "bankAccountFieldQuery", bankAccountFieldQuery);
-            return ApiClient.Query<BankAccountFieldResponse>(BuildPath("validation/bank-accounts", country.ToString(), currency.ToString()),
+            CheckoutUtils.ValidateParams("country", country, "currency", currency, "bankAccountFieldQuery",
+                bankAccountFieldQuery);
+            return ApiClient.Query<BankAccountFieldResponse>(
+                BuildPath("validation/bank-accounts", country.ToString(), currency.ToString()),
                 SdkAuthorization(SdkAuthorizationType.OAuth), bankAccountFieldQuery, cancellationToken);
         }
     }

--- a/src/CheckoutSdk/Reconciliation/IReconciliationClient.cs
+++ b/src/CheckoutSdk/Reconciliation/IReconciliationClient.cs
@@ -1,14 +1,27 @@
 ﻿using Checkout.Common;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Checkout.Reconciliation
 {
     public interface IReconciliationClient
     {
-        Task<ReconciliationPaymentReportResponse> QueryPaymentsReport(ReconciliationQueryPaymentsFilter filter);
+        Task<ReconciliationPaymentReportResponse> QueryPaymentsReport(ReconciliationQueryPaymentsFilter filter,
+            CancellationToken cancellationToken = default);
 
-        Task<ReconciliationPaymentReportResponse> SinglePaymentReport(string paymentId);
+        Task<ReconciliationPaymentReportResponse> SinglePaymentReport(string paymentId,
+            CancellationToken cancellationToken = default);
 
-        Task<StatementReportResponse> QueryStatementsReport(QueryFilterDateRange filter);
+        Task<StatementReportResponse> QueryStatementsReport(QueryFilterDateRange filter,
+            CancellationToken cancellationToken = default);
+
+        Task<string> RetrieveCsvPaymentReport(QueryFilterDateRange filter,
+            CancellationToken cancellationToken = default);
+
+        Task<string> RetrieveCsvSingleStatementReport(string statementId,
+            CancellationToken cancellationToken = default);
+
+        Task<string> RetrieveCsvStatementsReport(QueryFilterDateRange filter,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/Reconciliation/ReconciliationClient.cs
+++ b/src/CheckoutSdk/Reconciliation/ReconciliationClient.cs
@@ -1,4 +1,5 @@
 ﻿using Checkout.Common;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Checkout.Reconciliation
@@ -7,6 +8,7 @@ namespace Checkout.Reconciliation
     {
         private const string ReportingPath = "reporting";
         private const string PaymentsPath = "payments";
+        private const string DownloadPath = "download";
         private const string StatementsPath = "statements";
 
         public ReconciliationClient(IApiClient apiClient, CheckoutConfiguration configuration) : base(apiClient,
@@ -14,25 +16,56 @@ namespace Checkout.Reconciliation
         {
         }
 
-        public Task<ReconciliationPaymentReportResponse> QueryPaymentsReport(ReconciliationQueryPaymentsFilter filter)
+        public Task<ReconciliationPaymentReportResponse> QueryPaymentsReport(ReconciliationQueryPaymentsFilter filter,
+            CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("filter", filter);
             return ApiClient.Query<ReconciliationPaymentReportResponse>(BuildPath(ReportingPath, PaymentsPath),
-                SdkAuthorization(), filter);
+                SdkAuthorization(), filter, cancellationToken);
         }
 
-        public Task<ReconciliationPaymentReportResponse> SinglePaymentReport(string paymentId)
+        public Task<ReconciliationPaymentReportResponse> SinglePaymentReport(string paymentId,
+            CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("paymentId", paymentId);
             return ApiClient.Get<ReconciliationPaymentReportResponse>(BuildPath(ReportingPath, PaymentsPath, paymentId),
-                SdkAuthorization());
+                SdkAuthorization(), cancellationToken);
         }
 
-        public Task<StatementReportResponse> QueryStatementsReport(QueryFilterDateRange filter)
+        public Task<StatementReportResponse> QueryStatementsReport(QueryFilterDateRange filter,
+            CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("filter", filter);
             return ApiClient.Query<StatementReportResponse>(BuildPath(ReportingPath, StatementsPath),
-                SdkAuthorization(), filter);
+                SdkAuthorization(), filter, cancellationToken);
+        }
+
+        public Task<string> RetrieveCsvPaymentReport(QueryFilterDateRange filter,
+            CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("filter", filter);
+            return ApiClient.Query<string>(BuildPath(ReportingPath, PaymentsPath, DownloadPath), SdkAuthorization(),
+                filter,
+                cancellationToken);
+        }
+
+        public Task<string> RetrieveCsvSingleStatementReport(string statementId,
+            CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("statementId", statementId);
+            return ApiClient.Query<string>(
+                BuildPath(ReportingPath, StatementsPath, statementId, PaymentsPath, DownloadPath), SdkAuthorization(),
+                null,
+                cancellationToken);
+        }
+
+        public Task<string> RetrieveCsvStatementsReport(QueryFilterDateRange filter,
+            CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("filter", filter);
+            return ApiClient.Query<string>(
+                BuildPath(ReportingPath, StatementsPath, DownloadPath), SdkAuthorization(), filter,
+                cancellationToken);
         }
     }
 }

--- a/test/CheckoutSdkTest/Disputes/Four/DisputesClientTest.cs
+++ b/test/CheckoutSdkTest/Disputes/Four/DisputesClientTest.cs
@@ -1,7 +1,7 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Disputes.Four

--- a/test/CheckoutSdkTest/Events/EventsClientTest.cs
+++ b/test/CheckoutSdkTest/Events/EventsClientTest.cs
@@ -1,8 +1,8 @@
+using Moq;
+using Shouldly;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Moq;
-using Shouldly;
 using Xunit;
 
 namespace Checkout.Events
@@ -26,10 +26,7 @@ namespace Checkout.Events
         [Fact]
         private async Task ShouldRetrieveAllEventTypes()
         {
-            var eventTypesResponse = new List<EventTypesResponse>
-            {
-                new EventTypesResponse()
-            };
+            var eventTypesResponse = new List<EventTypesResponse> {new EventTypesResponse()};
 
             _apiClient.Setup(apiClient =>
                     apiClient.Get<IList<EventTypesResponse>>("event-types?version=1.0", _authorization,
@@ -47,10 +44,7 @@ namespace Checkout.Events
         [Fact]
         private async Task ShouldRetrieveAllEventTypesWithoutVersion()
         {
-            var eventTypesResponse = new List<EventTypesResponse>
-            {
-                new EventTypesResponse()
-            };
+            var eventTypesResponse = new List<EventTypesResponse> {new EventTypesResponse()};
 
             _apiClient.Setup(apiClient =>
                     apiClient.Get<IList<EventTypesResponse>>("event-types", _authorization,

--- a/test/CheckoutSdkTest/Instruments/Four/InstrumentsClientTest.cs
+++ b/test/CheckoutSdkTest/Instruments/Four/InstrumentsClientTest.cs
@@ -1,3 +1,4 @@
+using Checkout.Common;
 using Checkout.Instruments.Four.Create;
 using Checkout.Instruments.Four.Get;
 using Checkout.Instruments.Four.Update;
@@ -109,16 +110,17 @@ namespace Checkout.Instruments.Four
             BankAccountFieldQuery bankAccountFieldQuery = new BankAccountFieldQuery();
 
             _sdkCredentials.Setup(credentials => credentials.GetSdkAuthorization(SdkAuthorizationType.OAuth))
-              .Returns(_authorization);
+                .Returns(_authorization);
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Query<BankAccountFieldResponse>("validation/bank-accounts/GB/GBP", _authorization, bankAccountFieldQuery,
-                        CancellationToken.None)).ReturnsAsync(() => new BankAccountFieldResponse());
+                apiClient.Query<BankAccountFieldResponse>("validation/bank-accounts/GB/GBP", _authorization,
+                    bankAccountFieldQuery, CancellationToken.None)).ReturnsAsync(() => new BankAccountFieldResponse());
 
             IInstrumentsClient client =
                 new InstrumentsClient(_apiClient.Object, _configuration.Object);
 
-            var response = await client.GetBankAccountFieldFormatting(Common.CountryCode.GB, Common.Currency.GBP, bankAccountFieldQuery);
+            var response = await client.GetBankAccountFieldFormatting(CountryCode.GB, Currency.GBP,
+                bankAccountFieldQuery);
 
             response.ShouldNotBeNull();
         }

--- a/test/CheckoutSdkTest/Reconciliation/ReconciliationClientTest.cs
+++ b/test/CheckoutSdkTest/Reconciliation/ReconciliationClientTest.cs
@@ -20,6 +20,7 @@ namespace Checkout.Reconciliation
         private readonly DateTime _from = new DateTime(2019, 2, 22, 12, 31, 44, 0, DateTimeKind.Utc);
         private readonly DateTime _to = new DateTime(2021, 12, 30, 13, 21, 34, 0, DateTimeKind.Utc);
         private const string Reference = "ORD-5023-4E89";
+        private const string Csv = "csv_content";
 
         public ReconciliationClientTest()
         {
@@ -103,6 +104,52 @@ namespace Checkout.Reconciliation
             //Assert
             response.ShouldNotBeNull();
             response.Count.ShouldBe(returnResponse.Count);
+        }
+
+        [Fact]
+        private async Task ShouldRetrieveCsvPaymentReport()
+        {
+            var request = new QueryFilterDateRange {To = _to, From = _from};
+
+            _apiClient.Setup(apiClient =>
+                    apiClient.Query<string>("reporting/payments/download", _authorization, request,
+                        CancellationToken.None))
+                .ReturnsAsync(() => Csv);
+
+            var response = await _reconciliationClient.RetrieveCsvPaymentReport(request);
+
+            response.ShouldNotBeNull();
+            response.ShouldBe(Csv);
+        }
+
+        [Fact]
+        private async Task ShouldRetrieveCsvSingleStatementReport()
+        {
+            _apiClient.Setup(apiClient =>
+                    apiClient.Query<string>("reporting/statements/id/payments/download", _authorization,
+                        It.IsAny<QueryFilterDateRange>(),
+                        CancellationToken.None))
+                .ReturnsAsync(() => Csv);
+
+            var response = await _reconciliationClient.RetrieveCsvSingleStatementReport("id");
+            response.ShouldNotBeNull();
+            response.ShouldBe(Csv);
+        }
+
+        [Fact]
+        private async Task ShouldRetrieveCsvStatementsReport()
+        {
+            var request = new QueryFilterDateRange {To = _to, From = _from};
+
+            _apiClient.Setup(apiClient =>
+                    apiClient.Query<string>("reporting/statements/download", _authorization, request,
+                        CancellationToken.None))
+                .ReturnsAsync(() => Csv);
+
+            var response = await _reconciliationClient.RetrieveCsvStatementsReport(request);
+
+            response.ShouldNotBeNull();
+            response.ShouldBe(Csv);
         }
     }
 }

--- a/test/CheckoutSdkTest/Reconciliation/ReconciliationIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Reconciliation/ReconciliationIntegrationTest.cs
@@ -1,0 +1,83 @@
+using Checkout.Common;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Checkout.Reconciliation
+{
+    public class ReconciliationIntegrationTest
+    {
+        private readonly QueryFilterDateRange _queryFilterDateRange = new QueryFilterDateRange
+        {
+            From = DateTime.Now.Subtract(TimeSpan.FromDays(30)), To = DateTime.Now
+        };
+
+        private readonly ICheckoutApi _productionApi = CheckoutSdk.DefaultSdk().StaticKeys()
+            .SecretKey(System.Environment.GetEnvironmentVariable("CHECKOUT_SECRET_KEY_PROD"))
+            .Environment(Environment.Production)
+            .Build();
+
+        [Fact(Skip = "Only works in Production")]
+        private async Task ShouldQueryPaymentsReport()
+        {
+            var query = new ReconciliationQueryPaymentsFilter
+            {
+                From = DateTime.Now.Subtract(TimeSpan.FromDays(30)), To = DateTime.Now
+            };
+
+            var response = await _productionApi.ReconciliationClient().QueryPaymentsReport(query);
+            response.ShouldNotBeNull();
+            response.Count.ShouldNotBeNull();
+            response.Count.GetValueOrDefault().ShouldBeGreaterThan(0);
+            response.Data.ShouldNotBeEmpty();
+        }
+
+        [Fact(Skip = "Only works in Production")]
+        private async Task ShouldSinglePaymentReport()
+        {
+            var response = await _productionApi.ReconciliationClient()
+                .SinglePaymentReport("pay_123456");
+            response.ShouldNotBeNull();
+            response.Count.ShouldNotBeNull();
+            response.Count.GetValueOrDefault().ShouldBeGreaterThan(0);
+            response.Data.ShouldNotBeEmpty();
+        }
+
+        [Fact(Skip = "Only works in Production")]
+        private async Task ShouldQueryStatementsReport()
+        {
+            var response = await _productionApi.ReconciliationClient().QueryStatementsReport(_queryFilterDateRange);
+            response.ShouldNotBeNull();
+            response.Count.ShouldNotBeNull();
+            response.Count.GetValueOrDefault().ShouldBeGreaterThan(0);
+            response.Data.ShouldNotBeEmpty();
+        }
+
+        [Fact(Skip = "Only works in Production")]
+        private async Task ShouldRetrieveCsvPaymentReport()
+        {
+            var response = await _productionApi.ReconciliationClient().RetrieveCsvPaymentReport(_queryFilterDateRange);
+            response.ShouldNotBeNull();
+            response.ShouldNotBeEmpty();
+        }
+
+        [Fact(Skip = "Only works in Production")]
+        private async Task ShouldRetrieveCsvSingleStatementReport()
+        {
+            var response = await _productionApi.ReconciliationClient()
+                .RetrieveCsvSingleStatementReport("reference");
+            response.ShouldNotBeNull();
+            response.ShouldNotBeEmpty();
+        }
+
+        [Fact(Skip = "Only works in Production")]
+        private async Task ShouldRetrieveCsvStatementsReport()
+        {
+            var response = await _productionApi.ReconciliationClient()
+                .RetrieveCsvStatementsReport(_queryFilterDateRange);
+            response.ShouldNotBeNull();
+            response.ShouldNotBeEmpty();
+        }
+    }
+}

--- a/test/CheckoutSdkTest/Workflows/Four/WorkflowEventsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Workflows/Four/WorkflowEventsIntegrationTest.cs
@@ -11,12 +11,12 @@ namespace Checkout.Workflows.Four
     public class WorkflowEventsIntegrationTest : AbstractWorkflowIntegrationTest
     {
         [Fact]
-        public async Task ShouldEventTypes()
+        public async Task ShouldGetEventTypes()
         {
             IList<EventTypesResponse> eventTypesResponses = await FourApi.WorkflowsClient().GetEventTypes();
 
             eventTypesResponses.ShouldNotBeNull();
-            eventTypesResponses.Count.ShouldBe(7);
+            eventTypesResponses.Count.ShouldBe(8);
 
             foreach (var eventType in eventTypesResponses)
             {


### PR DESCRIPTION
Adding `RetrieveCsvPaymentReport`, `RetrieveCsvSingleStatementReport` and `RetrieveCsvStatementsReport` missing operations. A few changes were performed to avoid Json deserialization at ApiClint level. To verify the functionality a few integration tests were added to this module (left disabled since they only work in production environment).