### PR TITLE
Provide dynamic deserialization on POST create instrument

### DIFF
--- a/src/CheckoutSdk/Instruments/Four/Create/CreateInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateInstrumentResponse.cs
@@ -1,12 +1,12 @@
 ﻿namespace Checkout.Instruments.Four.Create
 {
-    public abstract class CreateInstrumentResponse
+    public class CreateInstrumentResponse
     {
         public InstrumentType? Type { get; set; }
 
         public string Id { get; set; }
 
-        protected CreateInstrumentResponse(InstrumentType type)
+        public CreateInstrumentResponse(InstrumentType type)
         {
             Type = type;
         }

--- a/src/CheckoutSdk/Instruments/Four/Create/Util/CreateInstrumentResponseTypeConverter.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/Util/CreateInstrumentResponseTypeConverter.cs
@@ -1,0 +1,69 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Reflection;
+
+namespace Checkout.Instruments.Four.Create.Util
+{
+    public class CreateInstrumentResponseTypeConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(CreateInstrumentResponse).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var jObject = JObject.Load(reader);
+            var target = Create(jObject);
+            if (target != null)
+            {
+                serializer.Populate(jObject.CreateReader(), target);
+            }
+
+            return target;
+        }
+
+        public override void WriteJson(
+            JsonWriter writer,
+            object value,
+            Newtonsoft.Json.JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static CreateInstrumentResponse Create(JToken jToken)
+        {
+            CheckoutUtils.ValidateParams("jToken", jToken);
+            var sourceType = GetSourceType(jToken);
+            return Create(sourceType);
+        }
+
+        private static CreateInstrumentResponse Create(string type)
+        {
+            if (CheckoutUtils.GetEnumMemberValue(InstrumentType.BankAccount).Equals(type))
+            {
+                return new CreateBankAccountInstrumentResponse();
+            }
+
+            if (CheckoutUtils.GetEnumMemberValue(InstrumentType.Card).Equals(type))
+            {
+                return new CreateTokenInstrumentResponse();
+            }
+
+            return new CreateInstrumentResponse(
+                CheckoutUtils.GetEnumFromStringMemberValue<InstrumentType>(type));
+        }
+
+        private static string GetSourceType(JToken jObject)
+        {
+            return jObject.SelectToken(CheckoutUtils.Type)?.Value<string>()?.ToLowerInvariant();
+        }
+    }
+}

--- a/src/CheckoutSdk/Instruments/Four/IInstrumentsClient.cs
+++ b/src/CheckoutSdk/Instruments/Four/IInstrumentsClient.cs
@@ -7,8 +7,8 @@ namespace Checkout.Instruments.Four
 {
     public interface IInstrumentsClient
     {
-        Task<T> Create<T>(Create.CreateInstrumentRequest createInstrumentRequest,
-            CancellationToken cancellationToken = default) where T : Create.CreateInstrumentResponse;
+        Task<Create.CreateInstrumentResponse> Create(Create.CreateInstrumentRequest createInstrumentRequest,
+            CancellationToken cancellationToken = default);
 
         Task<GetInstrumentResponse> Get(string instrumentId, CancellationToken cancellationToken = default);
 

--- a/src/CheckoutSdk/Instruments/Four/InstrumentsClient.cs
+++ b/src/CheckoutSdk/Instruments/Four/InstrumentsClient.cs
@@ -14,11 +14,11 @@ namespace Checkout.Instruments.Four
         {
         }
 
-        public Task<T> Create<T>(Create.CreateInstrumentRequest createInstrumentRequest,
-            CancellationToken cancellationToken = default) where T : Create.CreateInstrumentResponse
+        public Task<Create.CreateInstrumentResponse> Create(Create.CreateInstrumentRequest createInstrumentRequest,
+            CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("createInstrumentRequest", createInstrumentRequest);
-            return ApiClient.Post<T>(
+            return ApiClient.Post<Create.CreateInstrumentResponse>(
                 InstrumentsPath,
                 SdkAuthorization(),
                 createInstrumentRequest,

--- a/src/CheckoutSdk/JsonSerializer.cs
+++ b/src/CheckoutSdk/JsonSerializer.cs
@@ -1,3 +1,4 @@
+using Checkout.Instruments.Four.Create.Util;
 using Checkout.Instruments.Four.Get.Util;
 using Checkout.Instruments.Four.Update.Util;
 using Checkout.Workflows.Four.Actions.Response.Util;
@@ -41,12 +42,13 @@ namespace Checkout
             var settings = new JsonSerializerSettings
             {
                 NullValueHandling = NullValueHandling.Ignore,
-                ContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() },
+                ContractResolver = new DefaultContractResolver {NamingStrategy = new SnakeCaseNamingStrategy()},
                 Converters = new JsonConverter[]
                 {
                     new StringEnumConverter(),
                     // Instruments CS2
-                    new GetInstrumentResponseTypeConverter(), new UpdateInstrumentResponseTypeConverter(),
+                    new CreateInstrumentResponseTypeConverter(), new GetInstrumentResponseTypeConverter(),
+                    new UpdateInstrumentResponseTypeConverter(),
                     // Workflows CS2
                     new WorkflowActionTypeResponseConverter(), new WorkflowConditionTypeResponseConverter(),
                     GetConverterDateTimeToIso()

--- a/test/CheckoutSdkTest/Instruments/Four/InstrumentsClientTest.cs
+++ b/test/CheckoutSdkTest/Instruments/Four/InstrumentsClientTest.cs
@@ -53,7 +53,7 @@ namespace Checkout.Instruments.Four
             var createInstrumentResponse = new CreateBankAccountInstrumentResponse();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<CreateBankAccountInstrumentResponse>("instruments", _authorization,
+                    apiClient.Post<Create.CreateInstrumentResponse>("instruments", _authorization,
                         createInstrumentRequest,
                         CancellationToken.None, null))
                 .ReturnsAsync(() => createInstrumentResponse);
@@ -61,7 +61,7 @@ namespace Checkout.Instruments.Four
             IInstrumentsClient client =
                 new InstrumentsClient(_apiClient.Object, _configuration.Object);
 
-            var response = await client.Create<CreateBankAccountInstrumentResponse>(createInstrumentRequest);
+            var response = await client.Create(createInstrumentRequest);
 
             response.ShouldNotBeNull();
             response.ShouldBe(createInstrumentResponse);

--- a/test/CheckoutSdkTest/Instruments/Four/InstrumentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Instruments/Four/InstrumentsIntegrationTest.cs
@@ -1,11 +1,11 @@
-﻿using System.Threading.Tasks;
-using Checkout.Common;
+﻿using Checkout.Common;
 using Checkout.Common.Four;
 using Checkout.Instruments.Four.Create;
 using Checkout.Instruments.Four.Get;
 using Checkout.Instruments.Four.Update;
 using Checkout.Payments.Four;
 using Shouldly;
+using System.Threading.Tasks;
 using Xunit;
 using CustomerRequest = Checkout.Customers.Four.CustomerRequest;
 
@@ -22,7 +22,7 @@ namespace Checkout.Instruments.Four
             var getResponse = await FourApi.InstrumentsClient().Get(tokenInstrument.Id);
             getResponse.ShouldNotBeNull();
 
-            var cardResponse = (GetCardInstrumentResponse) getResponse;
+            var cardResponse = (GetCardInstrumentResponse)getResponse;
             cardResponse.ShouldNotBeNull();
             cardResponse.Id.ShouldNotBeNull();
             cardResponse.Fingerprint.ShouldNotBeNull();
@@ -31,7 +31,6 @@ namespace Checkout.Instruments.Four
             cardResponse.Scheme.ShouldNotBeNull();
             cardResponse.Last4.ShouldNotBeNull();
             cardResponse.Bin.ShouldNotBeNull();
-            //cardResponse.Issuer.ShouldNotBeNull();
             cardResponse.IssuerCountry.ShouldNotBeNull();
             cardResponse.ProductId.ShouldNotBeNull();
             cardResponse.ProductType.ShouldNotBeNull();
@@ -52,17 +51,14 @@ namespace Checkout.Instruments.Four
             var tokenResponse = await RequestToken();
             tokenResponse.Token.ShouldNotBeNull();
 
-            var updateInstrumentTokenRequest = new UpdateTokenInstrumentRequest
-            {
-                Token = tokenResponse.Token
-            };
+            var updateInstrumentTokenRequest = new UpdateTokenInstrumentRequest {Token = tokenResponse.Token};
 
             var updateResponse =
                 await FourApi.InstrumentsClient().Update(tokenInstrument.Id, updateInstrumentTokenRequest);
 
             updateResponse.ShouldNotBeNull();
 
-            var updateCardInstrumentResponse = (UpdateCardInstrumentResponse) updateResponse;
+            var updateCardInstrumentResponse = (UpdateCardInstrumentResponse)updateResponse;
             updateCardInstrumentResponse.Fingerprint.ShouldNotBeNull();
         }
 
@@ -77,20 +73,12 @@ namespace Checkout.Instruments.Four
                 ExpiryMonth = 12,
                 ExpiryYear = 2024,
                 Name = "John Doe",
-                Customer = new UpdateCustomerRequest
-                {
-                    Id = tokenInstrument.Customer.Id,
-                    Default = true
-                },
+                Customer = new UpdateCustomerRequest {Id = tokenInstrument.Customer.Id, Default = true},
                 AccountHolder = new AccountHolder
                 {
                     FirstName = "John",
                     LastName = "Doe",
-                    Phone = new Phone
-                    {
-                        CountryCode = "+1",
-                        Number = "415 555 2671"
-                    },
+                    Phone = new Phone {CountryCode = "+1", Number = "415 555 2671"},
                     BillingAddress = new Address
                     {
                         AddressLine1 = "CheckoutSdk.com",
@@ -106,13 +94,13 @@ namespace Checkout.Instruments.Four
             var updateInstrumentResponse =
                 await FourApi.InstrumentsClient().Update(tokenInstrument.Id, updateCardInstrument);
             updateInstrumentResponse.ShouldNotBeNull();
-            var updateCardInstrumentResponse = (UpdateCardInstrumentResponse) updateInstrumentResponse;
+            var updateCardInstrumentResponse = (UpdateCardInstrumentResponse)updateInstrumentResponse;
             updateCardInstrumentResponse.Fingerprint.ShouldNotBeNullOrEmpty();
 
             var getResponse = await FourApi.InstrumentsClient().Get(tokenInstrument.Id);
             getResponse.ShouldNotBeNull();
 
-            var cardResponse = (GetCardInstrumentResponse) getResponse;
+            var cardResponse = (GetCardInstrumentResponse)getResponse;
             cardResponse.ShouldNotBeNull();
             cardResponse.Id.ShouldNotBeNull();
             cardResponse.Fingerprint.ShouldNotBeNull();
@@ -138,18 +126,9 @@ namespace Checkout.Instruments.Four
 
         private async Task<CreateTokenInstrumentResponse> CreateTokenInstrument()
         {
-            var phone = new Phone
-            {
-                CountryCode = "1",
-                Number = "4155552671"
-            };
+            var phone = new Phone {CountryCode = "1", Number = "4155552671"};
 
-            var customerRequest = new CustomerRequest
-            {
-                Email = GenerateRandomEmail(),
-                Name = "Testing",
-                Phone = phone
-            };
+            var customerRequest = new CustomerRequest {Email = GenerateRandomEmail(), Name = "Testing", Phone = phone};
 
             var customer = await FourApi.CustomersClient().Create(customerRequest);
             customer.ShouldNotBeNull();
@@ -162,11 +141,7 @@ namespace Checkout.Instruments.Four
             var tokenResponse = await RequestToken();
             tokenResponse.Token.ShouldNotBeNull();
 
-            var phone = new Phone
-            {
-                CountryCode = "+1",
-                Number = "415 555 2671"
-            };
+            var phone = new Phone {CountryCode = "+1", Number = "415 555 2671"};
 
             var billingAddress = new Address
             {
@@ -180,42 +155,35 @@ namespace Checkout.Instruments.Four
 
             var accountHolder = new AccountHolder
             {
-                FirstName = "John",
-                LastName = "Smith",
-                Phone = phone,
-                BillingAddress = billingAddress
+                FirstName = "John", LastName = "Smith", Phone = phone, BillingAddress = billingAddress
             };
 
-            var customer = new CreateCustomerInstrumentRequest
-            {
-                Id = customerId
-            };
+            var customer = new CreateCustomerInstrumentRequest {Id = customerId};
 
             var createTokenInstrumentRequest = new CreateTokenInstrumentRequest
             {
-                Token = tokenResponse.Token,
-                AccountHolder = accountHolder,
-                Customer = customer
+                Token = tokenResponse.Token, AccountHolder = accountHolder, Customer = customer
             };
 
             var response = await FourApi.InstrumentsClient()
-                .Create<CreateTokenInstrumentResponse>(createTokenInstrumentRequest);
-            response.ShouldNotBeNull();
-            response.Id.ShouldNotBeNull();
-            response.Fingerprint.ShouldNotBeNull();
-            response.ExpiryMonth.ShouldNotBeNull();
-            response.ExpiryYear.ShouldNotBeNull();
-            response.Scheme.ShouldNotBeNull();
-            response.Last4.ShouldNotBeNull();
-            response.Bin.ShouldNotBeNull();
-            //response.Issuer.ShouldNotBeNull();
-            response.IssuerCountry.ShouldNotBeNull();
-            response.ProductId.ShouldNotBeNull();
-            response.ProductType.ShouldNotBeNull();
-            response.Customer.ShouldNotBeNull();
-            response.CardType.ShouldNotBeNull();
-            response.CardCategory.ShouldNotBeNull();
-            return response;
+                .Create(createTokenInstrumentRequest);
+            response.ShouldBeAssignableTo(typeof(CreateTokenInstrumentResponse));
+            CreateTokenInstrumentResponse createTokenInstrumentResponse = (CreateTokenInstrumentResponse)response;
+            createTokenInstrumentResponse.ShouldNotBeNull();
+            createTokenInstrumentResponse.Id.ShouldNotBeNull();
+            createTokenInstrumentResponse.Fingerprint.ShouldNotBeNull();
+            createTokenInstrumentResponse.ExpiryMonth.ShouldNotBeNull();
+            createTokenInstrumentResponse.ExpiryYear.ShouldNotBeNull();
+            createTokenInstrumentResponse.Scheme.ShouldNotBeNull();
+            createTokenInstrumentResponse.Last4.ShouldNotBeNull();
+            createTokenInstrumentResponse.Bin.ShouldNotBeNull();
+            createTokenInstrumentResponse.IssuerCountry.ShouldNotBeNull();
+            createTokenInstrumentResponse.ProductId.ShouldNotBeNull();
+            createTokenInstrumentResponse.ProductType.ShouldNotBeNull();
+            createTokenInstrumentResponse.Customer.ShouldNotBeNull();
+            createTokenInstrumentResponse.CardType.ShouldNotBeNull();
+            createTokenInstrumentResponse.CardCategory.ShouldNotBeNull();
+            return createTokenInstrumentResponse;
         }
     }
 }


### PR DESCRIPTION
The POST create instrument operation was enforcing the user of the SDK to specify the type used to deserialize in compile time. This changes aim to select the type automatically depending on the response metadata `type`.