### PR TITLE
Added support for HttpMetadata on SDK responses

### DIFF
--- a/src/CheckoutSdk/Apm/Ideal/IdealInfo.cs
+++ b/src/CheckoutSdk/Apm/Ideal/IdealInfo.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Apm.Ideal
 {
-    public class IdealInfo
+    public class IdealInfo : HttpMetadata
     {
         [JsonProperty(PropertyName = "_links")]
         public IdealInfoLinks Links { get; set; }

--- a/src/CheckoutSdk/Apm/Sepa/SepaClient.cs
+++ b/src/CheckoutSdk/Apm/Sepa/SepaClient.cs
@@ -29,7 +29,8 @@ namespace Checkout.Apm.Sepa
                 BuildPath(SepaMandatesPath, mandateId, CancelPath),
                 SdkAuthorization(),
                 null,
-                cancellationToken);
+                cancellationToken,
+                null);
         }
 
         public Task<MandateResponse> GetMandateViaPpro(string mandateId, CancellationToken cancellationToken = default)
@@ -46,7 +47,8 @@ namespace Checkout.Apm.Sepa
                 BuildPath(PproPath, SepaMandatesPath, mandateId, CancelPath),
                 SdkAuthorization(),
                 null,
-                cancellationToken);
+                cancellationToken,
+                null);
         }
     }
 }

--- a/src/CheckoutSdk/Apm/Sepa/SepaResource.cs
+++ b/src/CheckoutSdk/Apm/Sepa/SepaResource.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Apm.Sepa
 {
-    public class SepaResource
+    public class SepaResource : HttpMetadata
     {
         public SepaResource()
         {

--- a/src/CheckoutSdk/CheckoutFourSdk.cs
+++ b/src/CheckoutSdk/CheckoutFourSdk.cs
@@ -1,6 +1,6 @@
+using Checkout.Four;
 using System;
 using System.Collections.Generic;
-using Checkout.Four;
 
 namespace Checkout
 {

--- a/src/CheckoutSdk/Common/Resource.cs
+++ b/src/CheckoutSdk/Common/Resource.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Common
 {
-    public class Resource
+    public class Resource : HttpMetadata
     {
         public Resource()
         {

--- a/src/CheckoutSdk/ContentsResponse.cs
+++ b/src/CheckoutSdk/ContentsResponse.cs
@@ -1,0 +1,7 @@
+namespace Checkout
+{
+    public class ContentsResponse : HttpMetadata
+    {
+        public string Content { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Customers/CustomerDetailsResponse.cs
+++ b/src/CheckoutSdk/Customers/CustomerDetailsResponse.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Customers
 {
-    public class CustomerDetailsResponse
+    public class CustomerDetailsResponse : HttpMetadata
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Customers/CustomersClient.cs
+++ b/src/CheckoutSdk/Customers/CustomersClient.cs
@@ -26,18 +26,18 @@ namespace Checkout.Customers
             return ApiClient.Post<IdResponse>(Customers, SdkAuthorization(), customerRequest, cancellationToken, null);
         }
 
-        public Task<object> Update(string customerId, CustomerRequest customerRequest,
+        public Task<EmptyResponse> Update(string customerId, CustomerRequest customerRequest,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("customerId", customerId, "customerRequest", customerRequest);
-            return ApiClient.Patch<object>(BuildPath(Customers, customerId), SdkAuthorization(), customerRequest,
+            return ApiClient.Patch<EmptyResponse>(BuildPath(Customers, customerId), SdkAuthorization(), customerRequest,
                 cancellationToken);
         }
 
-        public Task<object> Delete(string customerId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> Delete(string customerId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("customerId", customerId);
-            return ApiClient.Delete<object>(BuildPath(Customers, customerId), SdkAuthorization(), cancellationToken);
+            return ApiClient.Delete<EmptyResponse>(BuildPath(Customers, customerId), SdkAuthorization(), cancellationToken);
         }
     }
 }

--- a/src/CheckoutSdk/Customers/Four/CustomersClient.cs
+++ b/src/CheckoutSdk/Customers/Four/CustomersClient.cs
@@ -26,19 +26,19 @@ namespace Checkout.Customers.Four
             return ApiClient.Post<IdResponse>(Customers, SdkAuthorization(), customerRequest, cancellationToken, null);
         }
 
-        public Task<object> Update(string customerId, CustomerRequest customerRequest,
+        public Task<EmptyResponse> Update(string customerId, CustomerRequest customerRequest,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("customerId", customerId, "customerRequest", customerRequest);
-            return ApiClient.Patch<object>(BuildPath(Customers, customerId), SdkAuthorization(), customerRequest,
+            return ApiClient.Patch<EmptyResponse>(BuildPath(Customers, customerId), SdkAuthorization(), customerRequest,
                 cancellationToken,
                 null);
         }
 
-        public Task<object> Delete(string customerId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> Delete(string customerId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("customerId", customerId);
-            return ApiClient.Delete<object>(BuildPath(Customers, customerId), SdkAuthorization(), cancellationToken);
+            return ApiClient.Delete<EmptyResponse>(BuildPath(Customers, customerId), SdkAuthorization(), cancellationToken);
         }
     }
 }

--- a/src/CheckoutSdk/Customers/Four/ICustomersClient.cs
+++ b/src/CheckoutSdk/Customers/Four/ICustomersClient.cs
@@ -10,9 +10,9 @@ namespace Checkout.Customers.Four
 
         Task<IdResponse> Create(CustomerRequest customerRequest, CancellationToken cancellationToken = default);
 
-        Task<object> Update(string customerId, CustomerRequest customerRequest,
+        Task<EmptyResponse> Update(string customerId, CustomerRequest customerRequest,
             CancellationToken cancellationToken = default);
 
-        Task<object> Delete(string customerId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> Delete(string customerId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/Customers/ICustomersClient.cs
+++ b/src/CheckoutSdk/Customers/ICustomersClient.cs
@@ -10,9 +10,9 @@ namespace Checkout.Customers
 
         Task<IdResponse> Create(CustomerRequest customerRequest, CancellationToken cancellationToken = default);
 
-        Task<object> Update(string customerId, CustomerRequest customerRequest,
+        Task<EmptyResponse> Update(string customerId, CustomerRequest customerRequest,
             CancellationToken cancellationToken = default);
 
-        Task<object> Delete(string customerId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> Delete(string customerId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/Disputes/DisputeDetailsResponse.cs
+++ b/src/CheckoutSdk/Disputes/DisputeDetailsResponse.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Disputes
 {
-    public class DisputeDetailsResponse
+    public class DisputeDetailsResponse : HttpMetadata
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputeEvidenceResponse.cs
+++ b/src/CheckoutSdk/Disputes/DisputeEvidenceResponse.cs
@@ -1,6 +1,6 @@
 namespace Checkout.Disputes
 {
-    public class DisputeEvidenceResponse
+    public class DisputeEvidenceResponse : HttpMetadata
     {
         public string ProofOfDeliveryOrServiceFile { get; set; }
 

--- a/src/CheckoutSdk/Disputes/DisputesClient.cs
+++ b/src/CheckoutSdk/Disputes/DisputesClient.cs
@@ -31,18 +31,18 @@ namespace Checkout.Disputes
                 cancellationToken);
         }
 
-        public Task<object> Accept(string disputeId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> Accept(string disputeId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("disputeId", disputeId);
-            return ApiClient.Post<object>(BuildPath(DisputesPath, disputeId, AcceptPath), SdkAuthorization(), null,
-                cancellationToken);
+            return ApiClient.Post<EmptyResponse>(BuildPath(DisputesPath, disputeId, AcceptPath), SdkAuthorization(), null,
+                cancellationToken, null);
         }
 
-        public Task<object> PutEvidence(string disputeId, DisputeEvidenceRequest disputeEvidenceRequest,
+        public Task<EmptyResponse> PutEvidence(string disputeId, DisputeEvidenceRequest disputeEvidenceRequest,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("disputeId", disputeId, "disputeEvidenceRequest", disputeEvidenceRequest);
-            return ApiClient.Put<object>(BuildPath(DisputesPath, disputeId, EvidencePath), SdkAuthorization(),
+            return ApiClient.Put<EmptyResponse>(BuildPath(DisputesPath, disputeId, EvidencePath), SdkAuthorization(),
                 disputeEvidenceRequest,
                 cancellationToken);
         }
@@ -56,11 +56,11 @@ namespace Checkout.Disputes
                 cancellationToken);
         }
 
-        public Task<object> SubmitEvidence(string disputeId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> SubmitEvidence(string disputeId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("disputeId", disputeId);
-            return ApiClient.Post<object>(BuildPath(DisputesPath, disputeId, EvidencePath), SdkAuthorization(), null,
-                cancellationToken);
+            return ApiClient.Post<EmptyResponse>(BuildPath(DisputesPath, disputeId, EvidencePath), SdkAuthorization(), null,
+                cancellationToken, null);
         }
     }
 }

--- a/src/CheckoutSdk/Disputes/DisputesQueryResponse.cs
+++ b/src/CheckoutSdk/Disputes/DisputesQueryResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Disputes
 {
-    public class DisputesQueryResponse
+    public class DisputesQueryResponse : HttpMetadata
     {
         public int? Limit { get; set; }
 

--- a/src/CheckoutSdk/Disputes/IDisputesClient.cs
+++ b/src/CheckoutSdk/Disputes/IDisputesClient.cs
@@ -1,4 +1,3 @@
-using Checkout.Common;
 using Checkout.Files;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,13 +10,13 @@ namespace Checkout.Disputes
 
         Task<DisputeDetailsResponse> GetDisputeDetails(string disputeId, CancellationToken cancellationToken = default);
 
-        Task<object> Accept(string disputeId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> Accept(string disputeId, CancellationToken cancellationToken = default);
 
-        Task<object> PutEvidence(string disputeId, DisputeEvidenceRequest disputeEvidenceRequest,
+        Task<EmptyResponse> PutEvidence(string disputeId, DisputeEvidenceRequest disputeEvidenceRequest,
             CancellationToken cancellationToken = default);
 
         Task<DisputeEvidenceResponse> GetEvidence(string disputeId, CancellationToken cancellationToken = default);
 
-        Task<object> SubmitEvidence(string disputeId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> SubmitEvidence(string disputeId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/EmptyResponse.cs
+++ b/src/CheckoutSdk/EmptyResponse.cs
@@ -1,0 +1,6 @@
+namespace Checkout
+{
+    public class EmptyResponse : HttpMetadata
+    {
+    }
+}

--- a/src/CheckoutSdk/Events/EventsClient.cs
+++ b/src/CheckoutSdk/Events/EventsClient.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +14,7 @@ namespace Checkout.Events
         {
         }
 
-        public Task<IList<EventTypesResponse>> RetrieveAllEventTypes(string version = null,
+        public Task<ItemsResponse<EventTypesResponse>> RetrieveAllEventTypes(string version = null,
             CancellationToken cancellationToken = default)
         {
             var eventTypesPath = "event-types";
@@ -24,7 +23,7 @@ namespace Checkout.Events
                 eventTypesPath = $"{eventTypesPath}?version={version}";
             }
 
-            return ApiClient.Get<IList<EventTypesResponse>>(eventTypesPath, SdkAuthorization(), cancellationToken);
+            return ApiClient.Get<ItemsResponse<EventTypesResponse>>(eventTypesPath, SdkAuthorization(), cancellationToken);
         }
 
         public Task<EventsPageResponse> RetrieveEvents(RetrieveEventsRequest eventsRequest,
@@ -50,19 +49,19 @@ namespace Checkout.Events
                 SdkAuthorization(), cancellationToken);
         }
 
-        public Task<object> RetryWebhook(string eventId, string webhookId,
+        public Task<EmptyResponse> RetryWebhook(string eventId, string webhookId,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("eventId", eventId, "webhookId", webhookId);
-            return ApiClient.Post<object>(BuildPath(EventsPath, eventId, WebhooksPath, webhookId, RetryPath),
-                SdkAuthorization(), null, cancellationToken);
+            return ApiClient.Post<EmptyResponse>(BuildPath(EventsPath, eventId, WebhooksPath, webhookId, RetryPath),
+                SdkAuthorization(), null, cancellationToken, null);
         }
 
-        public Task<object> RetryAllWebhooks(string eventId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> RetryAllWebhooks(string eventId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("eventId", eventId);
-            return ApiClient.Post<object>(BuildPath(EventsPath, eventId, WebhooksPath, RetryPath),
-                SdkAuthorization(), null, cancellationToken);
+            return ApiClient.Post<EmptyResponse>(BuildPath(EventsPath, eventId, WebhooksPath, RetryPath),
+                SdkAuthorization(), null, cancellationToken, null);
         }
     }
 }

--- a/src/CheckoutSdk/Events/EventsPageResponse.cs
+++ b/src/CheckoutSdk/Events/EventsPageResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Events
 {
-    public class EventsPageResponse
+    public class EventsPageResponse : HttpMetadata
     {
         public int? TotalCount { get; set; }
 

--- a/src/CheckoutSdk/Events/IEventsClient.cs
+++ b/src/CheckoutSdk/Events/IEventsClient.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -6,7 +5,7 @@ namespace Checkout.Events
 {
     public interface IEventsClient
     {
-        Task<IList<EventTypesResponse>> RetrieveAllEventTypes(string version = null,
+        Task<ItemsResponse<EventTypesResponse>> RetrieveAllEventTypes(string version = null,
             CancellationToken cancellationToken = default);
 
         Task<EventsPageResponse> RetrieveEvents(RetrieveEventsRequest eventsRequest,
@@ -17,9 +16,9 @@ namespace Checkout.Events
         Task<EventNotificationResponse> RetrieveEventNotification(string eventId, string notificationId,
             CancellationToken cancellationToken = default);
 
-        Task<object> RetryWebhook(string eventId, string webhookId,
+        Task<EmptyResponse> RetryWebhook(string eventId, string webhookId,
             CancellationToken cancellationToken = default);
 
-        Task<object> RetryAllWebhooks(string eventId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> RetryAllWebhooks(string eventId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/Forex/QuoteResponse.cs
+++ b/src/CheckoutSdk/Forex/QuoteResponse.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Checkout.Forex
 {
-    public class QuoteResponse
+    public class QuoteResponse : HttpMetadata
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/HttpMetadata.cs
+++ b/src/CheckoutSdk/HttpMetadata.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Checkout
+{
+    public class HttpMetadata
+    {
+        public int? HttpStatusCode { get; set; }
+
+        public string Body { get; set; }
+
+        public IDictionary<string, string> ResponseHeaders { get; set; }
+    }
+}

--- a/src/CheckoutSdk/IApiClient.cs
+++ b/src/CheckoutSdk/IApiClient.cs
@@ -1,4 +1,3 @@
-using Checkout.Common;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -11,14 +10,16 @@ namespace Checkout
         Task<TResult> Get<TResult>(
             string path,
             SdkAuthorization authorization,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default)
+            where TResult : HttpMetadata;
 
         Task<TResult> Post<TResult>(
             string path,
             SdkAuthorization authorization,
             object request = null,
             CancellationToken cancellationToken = default,
-            string idempotencyKey = null);
+            string idempotencyKey = null)
+            where TResult : HttpMetadata;
 
         Task<TResult> Post<TResult>(
             string path,
@@ -26,31 +27,36 @@ namespace Checkout
             IDictionary<int, Type> resultTypeMappings,
             object request = null,
             CancellationToken cancellationToken = default,
-            string idempotencyKey = null) where TResult : Resource;
+            string idempotencyKey = null) 
+            where TResult : HttpMetadata;
 
         Task<TResult> Patch<TResult>(
             string path,
             SdkAuthorization authorization,
             object request = null,
             CancellationToken cancellationToken = default,
-            string idempotencyKey = null);
+            string idempotencyKey = null)
+            where TResult : HttpMetadata;
 
         Task<TResult> Put<TResult>(
             string path,
             SdkAuthorization authorization,
             object request = null,
             CancellationToken cancellationToken = default,
-            string idempotencyKey = null);
+            string idempotencyKey = null)
+            where TResult : HttpMetadata;
 
         Task<TResult> Delete<TResult>(
             string path,
             SdkAuthorization authorization,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default)
+            where TResult : HttpMetadata;
 
         Task<TResult> Query<TResult>(
             string path,
             SdkAuthorization authorization,
             object request = null,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default)
+            where TResult : HttpMetadata;
     }
 }

--- a/src/CheckoutSdk/Instruments/CreateInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/CreateInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments
 {
-    public class CreateInstrumentResponse
+    public class CreateInstrumentResponse : HttpMetadata
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Instruments/Four/Create/CreateBankAccountInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateBankAccountInstrumentResponse.cs
@@ -1,5 +1,4 @@
-﻿using Checkout.Common;
-using Checkout.Common.Four;
+﻿using Checkout.Common.Four;
 
 namespace Checkout.Instruments.Four.Create
 {

--- a/src/CheckoutSdk/Instruments/Four/Create/CreateInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Create/CreateInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Create
 {
-    public class CreateInstrumentResponse
+    public class CreateInstrumentResponse : HttpMetadata
     {
         public InstrumentType? Type { get; set; }
 

--- a/src/CheckoutSdk/Instruments/Four/Get/BankAccountFieldResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Get/BankAccountFieldResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Get
 {
-    public class BankAccountFieldResponse
+    public class BankAccountFieldResponse : HttpMetadata
     {
         public IList<BankAccountSection> Sections { get; set; }
     }

--- a/src/CheckoutSdk/Instruments/Four/Get/GetInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Get/GetInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments.Four.Get
 {
-    public class GetInstrumentResponse
+    public class GetInstrumentResponse : HttpMetadata
     {
         public GetInstrumentResponse()
         {

--- a/src/CheckoutSdk/Instruments/Four/IInstrumentsClient.cs
+++ b/src/CheckoutSdk/Instruments/Four/IInstrumentsClient.cs
@@ -16,7 +16,7 @@ namespace Checkout.Instruments.Four
             Update.UpdateInstrumentRequest updateInstrumentRequest,
             CancellationToken cancellationToken = default);
 
-        Task<object> Delete(string instrumentId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> Delete(string instrumentId, CancellationToken cancellationToken = default);
 
         Task<BankAccountFieldResponse> GetBankAccountFieldFormatting(CountryCode country, Currency currency,
             BankAccountFieldQuery bankAccountFieldQuery, CancellationToken cancellationToken = default);

--- a/src/CheckoutSdk/Instruments/Four/InstrumentsClient.cs
+++ b/src/CheckoutSdk/Instruments/Four/InstrumentsClient.cs
@@ -45,10 +45,10 @@ namespace Checkout.Instruments.Four
                 cancellationToken);
         }
 
-        public Task<object> Delete(string instrumentId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> Delete(string instrumentId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("instrumentId", instrumentId);
-            return ApiClient.Delete<object>(
+            return ApiClient.Delete<EmptyResponse>(
                 BuildPath(InstrumentsPath, instrumentId),
                 SdkAuthorization(),
                 cancellationToken);

--- a/src/CheckoutSdk/Instruments/Four/Update/UpdateInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/Four/Update/UpdateInstrumentResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments.Four.Update
 {
-    public class UpdateInstrumentResponse
+    public class UpdateInstrumentResponse : HttpMetadata
     {
         public InstrumentType? Type { get; set; }
 

--- a/src/CheckoutSdk/Instruments/IInstrumentsClient.cs
+++ b/src/CheckoutSdk/Instruments/IInstrumentsClient.cs
@@ -13,6 +13,6 @@ namespace Checkout.Instruments
         Task<UpdateInstrumentResponse> Update(string instrumentId, UpdateInstrumentRequest updateInstrumentRequest,
             CancellationToken cancellationToken = default);
 
-        Task<object> Delete(string instrumentId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> Delete(string instrumentId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/Instruments/InstrumentsClient.cs
+++ b/src/CheckoutSdk/Instruments/InstrumentsClient.cs
@@ -43,10 +43,10 @@ namespace Checkout.Instruments
                 cancellationToken);
         }
 
-        public Task<object> Delete(string instrumentId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> Delete(string instrumentId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("instrumentId", instrumentId);
-            return ApiClient.Delete<object>(
+            return ApiClient.Delete<EmptyResponse>(
                 BuildPath(InstrumentsPath, instrumentId),
                 SdkAuthorization(),
                 cancellationToken);

--- a/src/CheckoutSdk/Instruments/RetrieveInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/RetrieveInstrumentResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Instruments
 {
-    public class RetrieveInstrumentResponse
+    public class RetrieveInstrumentResponse : HttpMetadata
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Instruments/UpdateInstrumentResponse.cs
+++ b/src/CheckoutSdk/Instruments/UpdateInstrumentResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Instruments
 {
-    public class UpdateInstrumentResponse
+    public class UpdateInstrumentResponse : HttpMetadata
     {
         public InstrumentType? Type { get; set; }
 

--- a/src/CheckoutSdk/ItemsResponse.cs
+++ b/src/CheckoutSdk/ItemsResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Checkout
+{
+    public class ItemsResponse<T> : HttpMetadata
+    {
+        public IList<T> Items { get; set; } = new List<T>();
+    }
+}

--- a/src/CheckoutSdk/ItemsResponseConverter.cs
+++ b/src/CheckoutSdk/ItemsResponseConverter.cs
@@ -1,0 +1,82 @@
+using Checkout.Events;
+using Checkout.Payments;
+using Checkout.Webhooks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+
+namespace Checkout
+{
+    public class ItemsResponseConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.IsGenericType && typeof(ItemsResponse<>).GetGenericTypeDefinition()
+                .IsAssignableFrom(objectType.GetGenericTypeDefinition());
+        }
+
+        public override void WriteJson(
+            JsonWriter writer,
+            object value,
+            Newtonsoft.Json.JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            Newtonsoft.Json.JsonSerializer serializer)
+        {
+            Type genericTypeDefinition = objectType.GetGenericTypeDefinition();
+            Type genericArgument = objectType.GetGenericArguments()[0];
+            Type constructed = genericTypeDefinition.MakeGenericType(genericArgument);
+
+            var wrapper = Activator.CreateInstance(constructed);
+
+            Type instanceType = typeof(List<>).MakeGenericType(genericArgument);
+            var targetItems = Activator.CreateInstance(instanceType);
+            JContainer jObject = JArray.Load(reader);
+
+            if (targetItems != null)
+            {
+                serializer.Populate(jObject.CreateReader(), targetItems);
+            }
+
+            CheckAndSetItemsList(genericArgument, wrapper, targetItems);
+
+            return wrapper;
+        }
+
+        private static void CheckAndSetItemsList(Type genericArgument, object wrapper, object target)
+        {
+            if (genericArgument == typeof(WebhookResponse))
+            {
+                ((ItemsResponse<WebhookResponse>)wrapper).Items = (List<WebhookResponse>)target;
+            }
+            else if (genericArgument == typeof(EventTypesResponse))
+            {
+                ((ItemsResponse<EventTypesResponse>)wrapper).Items = (List<EventTypesResponse>)target;
+            }
+            else if (genericArgument == typeof(Workflows.Four.Events.EventTypesResponse))
+            {
+                ((ItemsResponse<Workflows.Four.Events.EventTypesResponse>)wrapper).Items =
+                    (List<Workflows.Four.Events.EventTypesResponse>)target;
+            }
+            else if (genericArgument == typeof(PaymentAction))
+            {
+                ((ItemsResponse<PaymentAction>)wrapper).Items =
+                    (List<PaymentAction>)target;
+            }
+            else if (genericArgument == typeof(Payments.Four.PaymentAction))
+            {
+                ((ItemsResponse<Payments.Four.PaymentAction>)wrapper).Items =
+                    (List<Payments.Four.PaymentAction>)target;
+            }
+        }
+    }
+}

--- a/src/CheckoutSdk/JsonSerializer.cs
+++ b/src/CheckoutSdk/JsonSerializer.cs
@@ -54,8 +54,10 @@ namespace Checkout
                     new WorkflowActionTypeResponseConverter(), new WorkflowConditionTypeResponseConverter(),
                     GetConverterDateTimeToIso(),
                     // Marketplace Payout Schedules
-                    new GetScheduleResponseTypeConverter(), new ScheduleResponseTypeConverter()
-                },
+                    new GetScheduleResponseTypeConverter(), new ScheduleResponseTypeConverter(),
+                    // Items Response
+                    new ItemsResponseConverter(),
+                }
             };
 
             configureSettings?.Invoke(settings);

--- a/src/CheckoutSdk/LogProvider.cs
+++ b/src/CheckoutSdk/LogProvider.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
 
 namespace Checkout
 {

--- a/src/CheckoutSdk/Marketplace/Balances/BalancesResponse.cs
+++ b/src/CheckoutSdk/Marketplace/Balances/BalancesResponse.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Marketplace.Balances
 {
-    public class BalancesResponse
+    public class BalancesResponse : HttpMetadata
     {
         public List<CurrencyAccountBalance> Data { get; set; }
     }

--- a/src/CheckoutSdk/Marketplace/IMarketplaceClient.cs
+++ b/src/CheckoutSdk/Marketplace/IMarketplaceClient.cs
@@ -18,7 +18,7 @@ namespace Checkout.Marketplace
         Task<OnboardEntityResponse> UpdateEntity(string entityId, OnboardEntityRequest entityRequest,
             CancellationToken cancellationToken = default);
 
-        Task<object> CreatePaymentInstrument(string entityId, MarketplacePaymentInstrument marketplacePaymentInstrument,
+        Task<EmptyResponse> CreatePaymentInstrument(string entityId, MarketplacePaymentInstrument marketplacePaymentInstrument,
             CancellationToken cancellationToken = default);
 
         Task<IdResponse> SubmitFile(MarketplaceFileRequest marketplaceFileRequest,
@@ -31,7 +31,7 @@ namespace Checkout.Marketplace
         Task<BalancesResponse> RetrieveEntityBalances(string entityId, BalancesQuery balancesQuery,
             CancellationToken cancellationToken = default);
 
-        Task<VoidResponse> UpdatePayoutSchedule(string entityId, Currency currency,
+        Task<EmptyResponse> UpdatePayoutSchedule(string entityId, Currency currency,
             UpdateScheduleRequest updateScheduleRequest, CancellationToken cancellationToken = default);
 
         Task<GetScheduleResponse>

--- a/src/CheckoutSdk/Marketplace/MarketplaceClient.cs
+++ b/src/CheckoutSdk/Marketplace/MarketplaceClient.cs
@@ -66,12 +66,12 @@ namespace Checkout.Marketplace
                 cancellationToken);
         }
 
-        public async Task<object> CreatePaymentInstrument(string entityId,
+        public async Task<EmptyResponse> CreatePaymentInstrument(string entityId,
             MarketplacePaymentInstrument marketplacePaymentInstrument, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("marketplacePaymentInstrument", marketplacePaymentInstrument, "entityId",
                 entityId);
-            return await ApiClient.Post<object>(
+            return await ApiClient.Post<EmptyResponse>(
                 BuildPath(MarketplacePath, EntitiesPath, entityId, InstrumentPath),
                 SdkAuthorization(SdkAuthorizationType.OAuth),
                 marketplacePaymentInstrument,
@@ -109,13 +109,13 @@ namespace Checkout.Marketplace
                 cancellationToken);
         }
 
-        public async Task<VoidResponse> UpdatePayoutSchedule(string entityId, Currency currency,
+        public async Task<EmptyResponse> UpdatePayoutSchedule(string entityId, Currency currency,
             UpdateScheduleRequest updateScheduleRequest,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("entityId", entityId, "currency", currency, "updateScheduleRequest",
                 updateScheduleRequest);
-            return await ApiClient.Put<VoidResponse>(
+            return await ApiClient.Put<EmptyResponse>(
                 BuildPath(MarketplacePath, EntitiesPath, entityId, PayoutSchedulePath),
                 SdkAuthorization(SdkAuthorizationType.OAuth),
                 new Dictionary<Currency, UpdateScheduleRequest>() {{currency, updateScheduleRequest}},

--- a/src/CheckoutSdk/Marketplace/Payout/Response/VoidResponse.cs
+++ b/src/CheckoutSdk/Marketplace/Payout/Response/VoidResponse.cs
@@ -1,8 +1,0 @@
-using Checkout.Common;
-
-namespace Checkout.Marketplace.Payout.Response
-{
-    public class VoidResponse : Resource
-    {
-    }
-}

--- a/src/CheckoutSdk/Payments/Four/IPaymentsClient.cs
+++ b/src/CheckoutSdk/Payments/Four/IPaymentsClient.cs
@@ -1,6 +1,5 @@
 ﻿using Checkout.Payments.Four.Request;
 using Checkout.Payments.Four.Response;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,7 +21,7 @@ namespace Checkout.Payments.Four
             string paymentId,
             CancellationToken cancellationToken = default);
 
-        Task<IList<PaymentAction>> GetPaymentActions(
+        Task<ItemsResponse<PaymentAction>> GetPaymentActions(
             string paymentId,
             CancellationToken cancellationToken = default);
 

--- a/src/CheckoutSdk/Payments/Four/PaymentsClient.cs
+++ b/src/CheckoutSdk/Payments/Four/PaymentsClient.cs
@@ -1,6 +1,5 @@
 using Checkout.Payments.Four.Request;
 using Checkout.Payments.Four.Response;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -52,12 +51,12 @@ namespace Checkout.Payments.Four
                 cancellationToken);
         }
 
-        public Task<IList<PaymentAction>> GetPaymentActions(
+        public Task<ItemsResponse<PaymentAction>> GetPaymentActions(
             string paymentId,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("paymentId", paymentId);
-            return ApiClient.Get<IList<PaymentAction>>(BuildPath(PaymentsPath, paymentId, "actions"),
+            return ApiClient.Get<ItemsResponse<PaymentAction>>(BuildPath(PaymentsPath, paymentId, "actions"),
                 SdkAuthorization(),
                 cancellationToken);
         }

--- a/src/CheckoutSdk/Payments/IPaymentsClient.cs
+++ b/src/CheckoutSdk/Payments/IPaymentsClient.cs
@@ -1,6 +1,5 @@
 ﻿using Checkout.Payments.Request;
 using Checkout.Payments.Response;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,7 +21,7 @@ namespace Checkout.Payments
             string paymentId,
             CancellationToken cancellationToken = default);
 
-        Task<IList<PaymentAction>> GetPaymentActions(
+        Task<ItemsResponse<PaymentAction>> GetPaymentActions(
             string paymentId,
             CancellationToken cancellationToken = default);
 

--- a/src/CheckoutSdk/Payments/PaymentsClient.cs
+++ b/src/CheckoutSdk/Payments/PaymentsClient.cs
@@ -1,6 +1,5 @@
 using Checkout.Payments.Request;
 using Checkout.Payments.Response;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -52,12 +51,12 @@ namespace Checkout.Payments
                 cancellationToken);
         }
 
-        public Task<IList<PaymentAction>> GetPaymentActions(
+        public Task<ItemsResponse<PaymentAction>> GetPaymentActions(
             string paymentId,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("paymentId", paymentId);
-            return ApiClient.Get<IList<PaymentAction>>(BuildPath(PaymentsPath, paymentId, "actions"),
+            return ApiClient.Get<ItemsResponse<PaymentAction>>(BuildPath(PaymentsPath, paymentId, "actions"),
                 SdkAuthorization(),
                 cancellationToken);
         }

--- a/src/CheckoutSdk/Reconciliation/IReconciliationClient.cs
+++ b/src/CheckoutSdk/Reconciliation/IReconciliationClient.cs
@@ -15,13 +15,13 @@ namespace Checkout.Reconciliation
         Task<StatementReportResponse> QueryStatementsReport(QueryFilterDateRange filter,
             CancellationToken cancellationToken = default);
 
-        Task<string> RetrieveCsvPaymentReport(QueryFilterDateRange filter,
+        Task<ContentsResponse> RetrieveCsvPaymentReport(QueryFilterDateRange filter,
             CancellationToken cancellationToken = default);
 
-        Task<string> RetrieveCsvSingleStatementReport(string statementId,
+        Task<ContentsResponse> RetrieveCsvSingleStatementReport(string statementId,
             CancellationToken cancellationToken = default);
 
-        Task<string> RetrieveCsvStatementsReport(QueryFilterDateRange filter,
+        Task<ContentsResponse> RetrieveCsvStatementsReport(QueryFilterDateRange filter,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/Reconciliation/PaymentReportData.cs
+++ b/src/CheckoutSdk/Reconciliation/PaymentReportData.cs
@@ -24,9 +24,9 @@ namespace Checkout.Reconciliation
 
         public CardCategory? CardCategory { get; set; }
 
-        public CountryCode? IssuerCountry { get; set; }
+        public string IssuerCountry { get; set; }
 
-        public CountryCode? MerchantCountry { get; set; }
+        public string MerchantCountry { get; set; }
 
         public string Mid { get; set; }
 

--- a/src/CheckoutSdk/Reconciliation/ReconciliationClient.cs
+++ b/src/CheckoutSdk/Reconciliation/ReconciliationClient.cs
@@ -40,30 +40,30 @@ namespace Checkout.Reconciliation
                 SdkAuthorization(), filter, cancellationToken);
         }
 
-        public Task<string> RetrieveCsvPaymentReport(QueryFilterDateRange filter,
+        public Task<ContentsResponse> RetrieveCsvPaymentReport(QueryFilterDateRange filter,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("filter", filter);
-            return ApiClient.Query<string>(BuildPath(ReportingPath, PaymentsPath, DownloadPath), SdkAuthorization(),
+            return ApiClient.Query<ContentsResponse>(BuildPath(ReportingPath, PaymentsPath, DownloadPath), SdkAuthorization(),
                 filter,
                 cancellationToken);
         }
 
-        public Task<string> RetrieveCsvSingleStatementReport(string statementId,
+        public Task<ContentsResponse> RetrieveCsvSingleStatementReport(string statementId,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("statementId", statementId);
-            return ApiClient.Query<string>(
+            return ApiClient.Query<ContentsResponse>(
                 BuildPath(ReportingPath, StatementsPath, statementId, PaymentsPath, DownloadPath), SdkAuthorization(),
                 null,
                 cancellationToken);
         }
 
-        public Task<string> RetrieveCsvStatementsReport(QueryFilterDateRange filter,
+        public Task<ContentsResponse> RetrieveCsvStatementsReport(QueryFilterDateRange filter,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("filter", filter);
-            return ApiClient.Query<string>(
+            return ApiClient.Query<ContentsResponse>(
                 BuildPath(ReportingPath, StatementsPath, DownloadPath), SdkAuthorization(), filter,
                 cancellationToken);
         }

--- a/src/CheckoutSdk/Sessions/ISessionsClient.cs
+++ b/src/CheckoutSdk/Sessions/ISessionsClient.cs
@@ -20,9 +20,9 @@ namespace Checkout.Sessions
         Task<GetSessionResponse> UpdateSession(string sessionSecret, string sessionId, ChannelData channelData,
             CancellationToken cancellationToken = default);
 
-        Task CompleteSession(string sessionId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> CompleteSession(string sessionId, CancellationToken cancellationToken = default);
 
-        Task CompleteSession(string sessionSecret, string sessionId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> CompleteSession(string sessionSecret, string sessionId, CancellationToken cancellationToken = default);
 
         Task<GetSessionResponseAfterChannelDataSupplied> Update3dsMethodCompletionIndicator(string sessionId,
             ThreeDsMethodCompletionRequest threeDsMethodCompletionRequest,

--- a/src/CheckoutSdk/Sessions/SessionsClient.cs
+++ b/src/CheckoutSdk/Sessions/SessionsClient.cs
@@ -1,5 +1,4 @@
-﻿using Checkout.Common;
-using Checkout.Sessions.Channel;
+﻿using Checkout.Sessions.Channel;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -65,17 +64,17 @@ namespace Checkout.Sessions
                 cancellationToken);
         }
 
-        public async Task CompleteSession(string sessionId, CancellationToken cancellationToken = default)
+        public async Task<EmptyResponse> CompleteSession(string sessionId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("sessionId", sessionId);
-            await CompleteSession(sessionId, SdkAuthorization(), cancellationToken);
+            return await CompleteSession(sessionId, SdkAuthorization(), cancellationToken);
         }
 
-        public async Task CompleteSession(string sessionSecret, string sessionId,
+        public async Task<EmptyResponse> CompleteSession(string sessionSecret, string sessionId,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("sessionSecret", sessionSecret, "sessionId", sessionId);
-            await CompleteSession(sessionId, SessionSecretAuthorization(sessionSecret), cancellationToken);
+            return await CompleteSession(sessionId, SessionSecretAuthorization(sessionSecret), cancellationToken);
         }
 
         public Task<GetSessionResponseAfterChannelDataSupplied> Update3dsMethodCompletionIndicator(string sessionId,
@@ -101,7 +100,7 @@ namespace Checkout.Sessions
         private async Task<SessionResponse> CreateSession(SessionRequest sessionRequest,
             CancellationToken cancellationToken = default)
         {
-            var resource = await ApiClient.Post<Resource>(SessionsPath, SdkAuthorization(), SessionResponseMappings,
+            var resource = await ApiClient.Post<HttpMetadata>(SessionsPath, SdkAuthorization(), SessionResponseMappings,
                 sessionRequest, cancellationToken);
 
             switch (resource)
@@ -133,11 +132,11 @@ namespace Checkout.Sessions
                 sdkAuthorization, channelData, cancellationToken);
         }
 
-        private async Task CompleteSession(string sessionId, SdkAuthorization sdkAuthorization,
+        private async Task<EmptyResponse> CompleteSession(string sessionId, SdkAuthorization sdkAuthorization,
             CancellationToken cancellationToken = default)
         {
-            await ApiClient.Post<object>(BuildPath(SessionsPath, sessionId, CompletePath), sdkAuthorization, null,
-                cancellationToken);
+            return await ApiClient.Post<EmptyResponse>(BuildPath(SessionsPath, sessionId, CompletePath), sdkAuthorization, null,
+                cancellationToken, null);
         }
 
         private async Task<GetSessionResponseAfterChannelDataSupplied> Update3dsMethodCompletionIndicator(

--- a/src/CheckoutSdk/Webhooks/IWebhooksClient.cs
+++ b/src/CheckoutSdk/Webhooks/IWebhooksClient.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -6,7 +5,7 @@ namespace Checkout.Webhooks
 {
     public interface IWebhooksClient
     {
-        Task<IList<WebhookResponse>> RetrieveWebhooks(CancellationToken cancellationToken = default);
+        Task<ItemsResponse<WebhookResponse>> RetrieveWebhooks(CancellationToken cancellationToken = default);
 
         Task<WebhookResponse> RegisterWebhook(WebhookRequest webhookRequest, string idempotencyKey = null,
             CancellationToken cancellationToken = default);
@@ -19,6 +18,6 @@ namespace Checkout.Webhooks
         Task<WebhookResponse> PatchWebhook(string webhookId, WebhookRequest webhookRequest,
             CancellationToken cancellationToken = default);
 
-        Task<object> RemoveWebhook(string webhookId, CancellationToken cancellationToken = default);
+        Task<EmptyResponse> RemoveWebhook(string webhookId, CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/Webhooks/WebhooksClient.cs
+++ b/src/CheckoutSdk/Webhooks/WebhooksClient.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,9 +12,9 @@ namespace Checkout.Webhooks
         {
         }
 
-        public Task<IList<WebhookResponse>> RetrieveWebhooks(CancellationToken cancellationToken = default)
+        public Task<ItemsResponse<WebhookResponse>> RetrieveWebhooks(CancellationToken cancellationToken = default)
         {
-            return ApiClient.Get<IList<WebhookResponse>>(WebhooksPath, SdkAuthorization(), cancellationToken);
+            return ApiClient.Get<ItemsResponse<WebhookResponse>>(WebhooksPath, SdkAuthorization(), cancellationToken);
         }
 
         public Task<WebhookResponse> RegisterWebhook(WebhookRequest webhookRequest, string idempotencyKey = null,
@@ -51,10 +50,10 @@ namespace Checkout.Webhooks
                 cancellationToken);
         }
 
-        public Task<object> RemoveWebhook(string webhookId, CancellationToken cancellationToken = default)
+        public Task<EmptyResponse> RemoveWebhook(string webhookId, CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("webhookId", webhookId);
-            return ApiClient.Delete<object>(BuildPath(WebhooksPath, webhookId), SdkAuthorization(), cancellationToken);
+            return ApiClient.Delete<EmptyResponse>(BuildPath(WebhooksPath, webhookId), SdkAuthorization(), cancellationToken);
         }
     }
 }

--- a/src/CheckoutSdk/Workflows/Four/Events/GetEventResponse.cs
+++ b/src/CheckoutSdk/Workflows/Four/Events/GetEventResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Checkout.Workflows.Four.Events
 {
-    public class GetEventResponse
+    public class GetEventResponse : HttpMetadata
     {
         public string Id { get; set; }
 

--- a/src/CheckoutSdk/Workflows/Four/Events/SubjectEventsResponse.cs
+++ b/src/CheckoutSdk/Workflows/Four/Events/SubjectEventsResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Workflows.Four.Events
 {
-    public class SubjectEventsResponse
+    public class SubjectEventsResponse : HttpMetadata
     {
         [JsonProperty(PropertyName = "data")] public IList<SubjectEvent> Events { get; set; }
     }

--- a/src/CheckoutSdk/Workflows/Four/GetWorkflowsResponse.cs
+++ b/src/CheckoutSdk/Workflows/Four/GetWorkflowsResponse.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Workflows.Four
 {
-    public class GetWorkflowsResponse
+    public class GetWorkflowsResponse : HttpMetadata
     {
         [JsonProperty(PropertyName = "data")] public IList<Workflow> Workflows { get; set; }
     }

--- a/src/CheckoutSdk/Workflows/Four/IWorkflowsClient.cs
+++ b/src/CheckoutSdk/Workflows/Four/IWorkflowsClient.cs
@@ -3,7 +3,6 @@ using Checkout.Workflows.Four.Actions.Response;
 using Checkout.Workflows.Four.Conditions.Request;
 using Checkout.Workflows.Four.Events;
 using Checkout.Workflows.Four.Reflows;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Checkout.Workflows.Four
@@ -18,15 +17,15 @@ namespace Checkout.Workflows.Four
 
         Task<UpdateWorkflowResponse> UpdateWorkflow(string workflowId, UpdateWorkflowRequest updateWorkflowRequest);
 
-        Task<object> RemoveWorkflow(string workflowId);
+        Task<EmptyResponse> RemoveWorkflow(string workflowId);
 
-        Task<object> UpdateWorkflowAction(string workflowId, string actionId,
+        Task<EmptyResponse> UpdateWorkflowAction(string workflowId, string actionId,
             WorkflowActionRequest workflowActionRequest);
 
-        Task<object> UpdateWorkflowCondition(string workflowId, string conditionId,
+        Task<EmptyResponse> UpdateWorkflowCondition(string workflowId, string conditionId,
             WorkflowConditionRequest workflowConditionRequest);
 
-        Task<IList<EventTypesResponse>> GetEventTypes();
+        Task<ItemsResponse<EventTypesResponse>> GetEventTypes();
 
         Task<SubjectEventsResponse> GetSubjectEvents(string subjectId);
 

--- a/src/CheckoutSdk/Workflows/Four/Reflows/ReflowResponse.cs
+++ b/src/CheckoutSdk/Workflows/Four/Reflows/ReflowResponse.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Checkout.Workflows.Four.Reflows
 {
-    public class ReflowResponse
+    public class ReflowResponse : HttpMetadata
     {
         public string RequestId { get; set; }
 

--- a/src/CheckoutSdk/Workflows/Four/UpdateWorkflowResponse.cs
+++ b/src/CheckoutSdk/Workflows/Four/UpdateWorkflowResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace Checkout.Workflows.Four
 {
-    public class UpdateWorkflowResponse
+    public class UpdateWorkflowResponse : HttpMetadata
     {
         public string Name { get; set; }
         

--- a/src/CheckoutSdk/Workflows/Four/WorkflowsClient.cs
+++ b/src/CheckoutSdk/Workflows/Four/WorkflowsClient.cs
@@ -3,7 +3,6 @@ using Checkout.Workflows.Four.Actions.Response;
 using Checkout.Workflows.Four.Conditions.Request;
 using Checkout.Workflows.Four.Events;
 using Checkout.Workflows.Four.Reflows;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Checkout.Workflows.Four
@@ -50,34 +49,34 @@ namespace Checkout.Workflows.Four
                 updateWorkflowRequest);
         }
 
-        public Task<object> RemoveWorkflow(string workflowId)
+        public Task<EmptyResponse> RemoveWorkflow(string workflowId)
         {
             CheckoutUtils.ValidateParams(WorkflowId, workflowId);
-            return ApiClient.Delete<object>(BuildPath(WorkflowsPath, workflowId), SdkAuthorization());
+            return ApiClient.Delete<EmptyResponse>(BuildPath(WorkflowsPath, workflowId), SdkAuthorization());
         }
 
-        public Task<object> UpdateWorkflowAction(string workflowId, string actionId,
+        public Task<EmptyResponse> UpdateWorkflowAction(string workflowId, string actionId,
             WorkflowActionRequest workflowActionRequest)
         {
             CheckoutUtils.ValidateParams(WorkflowId, workflowId, "actionId", actionId, "workflowActionRequest",
                 workflowActionRequest);
-            return ApiClient.Put<object>(BuildPath(WorkflowsPath, workflowId, ActionsPath, actionId),
+            return ApiClient.Put<EmptyResponse>(BuildPath(WorkflowsPath, workflowId, ActionsPath, actionId),
                 SdkAuthorization(),
                 workflowActionRequest);
         }
 
-        public Task<object> UpdateWorkflowCondition(string workflowId, string conditionId,
+        public Task<EmptyResponse> UpdateWorkflowCondition(string workflowId, string conditionId,
             WorkflowConditionRequest workflowConditionRequest)
         {
             CheckoutUtils.ValidateParams(WorkflowId, workflowId, "conditionId", conditionId,
                 "workflowConditionRequest", workflowConditionRequest);
-            return ApiClient.Put<object>(BuildPath(WorkflowsPath, workflowId, ConditionsPath, conditionId),
+            return ApiClient.Put<EmptyResponse>(BuildPath(WorkflowsPath, workflowId, ConditionsPath, conditionId),
                 SdkAuthorization(), workflowConditionRequest);
         }
 
-        public Task<IList<EventTypesResponse>> GetEventTypes()
+        public Task<ItemsResponse<EventTypesResponse>> GetEventTypes()
         {
-            return ApiClient.Get<IList<EventTypesResponse>>(BuildPath(WorkflowsPath, EventTypesPath),
+            return ApiClient.Get<ItemsResponse<EventTypesResponse>>(BuildPath(WorkflowsPath, EventTypesPath),
                 SdkAuthorization());
         }
 

--- a/test/CheckoutSdkTest/Apm/Ideal/IdealClientTest.cs
+++ b/test/CheckoutSdkTest/Apm/Ideal/IdealClientTest.cs
@@ -1,7 +1,7 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Apm.Ideal

--- a/test/CheckoutSdkTest/Apm/Klarna/KlarnaClientTest.cs
+++ b/test/CheckoutSdkTest/Apm/Klarna/KlarnaClientTest.cs
@@ -1,8 +1,8 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Checkout.Payments;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Apm.Klarna

--- a/test/CheckoutSdkTest/Apm/Klarna/KlarnaIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Apm/Klarna/KlarnaIntegrationTest.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Checkout.Common;
 using Shouldly;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Apm.Klarna

--- a/test/CheckoutSdkTest/Apm/Sepa/SepaClientTest.cs
+++ b/test/CheckoutSdkTest/Apm/Sepa/SepaClientTest.cs
@@ -1,7 +1,7 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Apm.Sepa

--- a/test/CheckoutSdkTest/CheckoutDefaultSdkTest.cs
+++ b/test/CheckoutSdkTest/CheckoutDefaultSdkTest.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Net.Http;
 using Moq;
 using Shouldly;
+using System;
+using System.Net.Http;
 using Xunit;
 using Xunit.Sdk;
 

--- a/test/CheckoutSdkTest/CheckoutFourSdkTest.cs
+++ b/test/CheckoutSdkTest/CheckoutFourSdkTest.cs
@@ -1,7 +1,7 @@
-using System;
-using System.Net.Http;
 using Moq;
 using Shouldly;
+using System;
+using System.Net.Http;
 using Xunit;
 using Xunit.Sdk;
 

--- a/test/CheckoutSdkTest/Customers/CustomersClientTest.cs
+++ b/test/CheckoutSdkTest/Customers/CustomersClientTest.cs
@@ -1,8 +1,8 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Checkout.Common;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Customers
@@ -62,10 +62,10 @@ namespace Checkout.Customers
             var customerRequest = new CustomerRequest();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Patch<object>("customers/cus_12345", _authorization, customerRequest,
+                    apiClient.Patch<EmptyResponse>("customers/cus_12345", _authorization, customerRequest,
                         CancellationToken.None
                         , null))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             ICustomersClient client = new CustomersClient(_apiClient.Object, _configuration.Object);
 
@@ -78,9 +78,9 @@ namespace Checkout.Customers
         private async Task ShouldDeleteCustomer()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Delete<object>("customers/cus_12345", _authorization,
+                    apiClient.Delete<EmptyResponse>("customers/cus_12345", _authorization,
                         CancellationToken.None))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             ICustomersClient client = new CustomersClient(_apiClient.Object, _configuration.Object);
 

--- a/test/CheckoutSdkTest/Customers/CustomersIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Customers/CustomersIntegrationTest.cs
@@ -84,7 +84,10 @@ namespace Checkout.Customers
             customerResponse.ShouldNotBeNull();
 
             var customerId = customerResponse.Id;
-            await DefaultApi.CustomersClient().Delete(customerId);
+            var emptyResponse = await DefaultApi.CustomersClient().Delete(customerId);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
             await AssertNotFound(DefaultApi.CustomersClient().Get(customerId));
         }
 

--- a/test/CheckoutSdkTest/Customers/Four/CustomersClientTest.cs
+++ b/test/CheckoutSdkTest/Customers/Four/CustomersClientTest.cs
@@ -62,10 +62,10 @@ namespace Checkout.Customers.Four
             var customerRequest = new CustomerRequest();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Patch<object>("customers/cus_12345", _authorization, customerRequest,
+                    apiClient.Patch<EmptyResponse>("customers/cus_12345", _authorization, customerRequest,
                         CancellationToken.None
                         , null))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             ICustomersClient client = new CustomersClient(_apiClient.Object, _configuration.Object);
 
@@ -78,9 +78,9 @@ namespace Checkout.Customers.Four
         private async Task ShouldDeleteCustomer()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Delete<object>("customers/cus_12345", _authorization,
+                    apiClient.Delete<EmptyResponse>("customers/cus_12345", _authorization,
                         CancellationToken.None))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             ICustomersClient client = new CustomersClient(_apiClient.Object, _configuration.Object);
 

--- a/test/CheckoutSdkTest/Customers/Four/CustomersIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Customers/Four/CustomersIntegrationTest.cs
@@ -70,7 +70,10 @@ namespace Checkout.Customers.Four
             customerResponse.ShouldNotBeNull();
 
             var customerId = customerResponse.Id;
-            await FourApi.CustomersClient().Delete(customerId);
+            var emptyResponse = await FourApi.CustomersClient().Delete(customerId);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             await AssertNotFound(FourApi.CustomersClient().Get(customerId));
         }

--- a/test/CheckoutSdkTest/Disputes/DisputesClientTest.cs
+++ b/test/CheckoutSdkTest/Disputes/DisputesClientTest.cs
@@ -65,9 +65,9 @@ namespace Checkout.Disputes
             const string disputeId = "dsp_s5151531";
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<object>($"disputes/{disputeId}/accept", _authorization, null, CancellationToken.None,
+                    apiClient.Post<EmptyResponse>($"disputes/{disputeId}/accept", _authorization, null, CancellationToken.None,
                         null))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IDisputesClient client = new DisputesClient(_apiClient.Object, _configuration.Object);
 
@@ -83,10 +83,10 @@ namespace Checkout.Disputes
             var request = new DisputeEvidenceRequest();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Put<object>($"disputes/{disputeId}/evidence", _authorization, request,
+                    apiClient.Put<EmptyResponse>($"disputes/{disputeId}/evidence", _authorization, request,
                         CancellationToken.None,
                         null))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IDisputesClient client = new DisputesClient(_apiClient.Object, _configuration.Object);
 
@@ -119,10 +119,10 @@ namespace Checkout.Disputes
             const string disputeId = "dsp_s5151531";
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<object>($"disputes/{disputeId}/evidence", _authorization, null,
+                    apiClient.Post<EmptyResponse>($"disputes/{disputeId}/evidence", _authorization, null,
                         CancellationToken.None,
                         null))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IDisputesClient client = new DisputesClient(_apiClient.Object, _configuration.Object);
 

--- a/test/CheckoutSdkTest/Disputes/DisputesIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Disputes/DisputesIntegrationTest.cs
@@ -89,7 +89,10 @@ namespace Checkout.Disputes
                 AdditionalEvidenceText = "Scanned document"
             };
             var disputeId = queryResponse.Data[0].Id;
-            await DefaultApi.DisputesClient().PutEvidence(disputeId, disputeEvidenceRequest);
+            var emptyResponse = await DefaultApi.DisputesClient().PutEvidence(disputeId, disputeEvidenceRequest);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             //Verify the dispute evidence
             var evidence = await DefaultApi.DisputesClient().GetEvidence(disputeId);

--- a/test/CheckoutSdkTest/Events/EventsClientTest.cs
+++ b/test/CheckoutSdkTest/Events/EventsClientTest.cs
@@ -1,6 +1,5 @@
 using Moq;
 using Shouldly;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -26,10 +25,10 @@ namespace Checkout.Events
         [Fact]
         private async Task ShouldRetrieveAllEventTypes()
         {
-            var eventTypesResponse = new List<EventTypesResponse> {new EventTypesResponse()};
+            var eventTypesResponse = new ItemsResponse<EventTypesResponse>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Get<IList<EventTypesResponse>>("event-types?version=1.0", _authorization,
+                    apiClient.Get<ItemsResponse<EventTypesResponse>>("event-types?version=1.0", _authorization,
                         CancellationToken.None))
                 .ReturnsAsync(() => eventTypesResponse);
 
@@ -44,10 +43,10 @@ namespace Checkout.Events
         [Fact]
         private async Task ShouldRetrieveAllEventTypesWithoutVersion()
         {
-            var eventTypesResponse = new List<EventTypesResponse> {new EventTypesResponse()};
+            var eventTypesResponse = new ItemsResponse<EventTypesResponse>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Get<IList<EventTypesResponse>>("event-types", _authorization,
+                    apiClient.Get<ItemsResponse<EventTypesResponse>>("event-types", _authorization,
                         CancellationToken.None))
                 .ReturnsAsync(() => eventTypesResponse);
 
@@ -116,9 +115,9 @@ namespace Checkout.Events
         private async Task ShouldRetryWebhook()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<object>("events/event_id/webhooks/webhook_id/retry", _authorization, null,
+                    apiClient.Post<EmptyResponse>("events/event_id/webhooks/webhook_id/retry", _authorization, null,
                         CancellationToken.None, null))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IEventsClient client = new EventsClient(_apiClient.Object, _configuration.Object);
 
@@ -131,9 +130,9 @@ namespace Checkout.Events
         private async Task ShouldRetryAllWebhooks()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<object>("events/event_id/webhooks/retry", _authorization, null,
+                    apiClient.Post<EmptyResponse>("events/event_id/webhooks/retry", _authorization, null,
                         CancellationToken.None, null))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IEventsClient client = new EventsClient(_apiClient.Object, _configuration.Object);
 

--- a/test/CheckoutSdkTest/Events/EventsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Events/EventsIntegrationTest.cs
@@ -32,18 +32,21 @@ namespace Checkout.Events
         [Fact]
         private async Task ShouldRetrieveDefaultEventTypes()
         {
-            var allEventTypes = await DefaultApi.EventsClient().RetrieveAllEventTypes();
+            var allEventTypesWrapper = await DefaultApi.EventsClient().RetrieveAllEventTypes();
+            var allEventTypes = allEventTypesWrapper.Items;
             allEventTypes.ShouldNotBeNull();
             allEventTypes.Count.ShouldBe(2);
             allEventTypes[0].EventTypes.ShouldNotBeNull();
 
-            var versionOneEventTypes = await DefaultApi.EventsClient().RetrieveAllEventTypes(allEventTypes[0].Version);
+            var versionOneEventTypesWrap = await DefaultApi.EventsClient().RetrieveAllEventTypes(allEventTypes[0].Version);
+            var versionOneEventTypes = versionOneEventTypesWrap.Items;
             versionOneEventTypes.ShouldNotBeNull();
             versionOneEventTypes.Count.ShouldBe(1);
             versionOneEventTypes[0].Version.ShouldBe(allEventTypes[0].Version);
             versionOneEventTypes[0].EventTypes.Count.ShouldBe(allEventTypes[0].EventTypes.Count);
 
-            var versionTwoEventTypes = await DefaultApi.EventsClient().RetrieveAllEventTypes(allEventTypes[1].Version);
+            var versionTwoEventTypesWrap = await DefaultApi.EventsClient().RetrieveAllEventTypes(allEventTypes[1].Version);
+            var versionTwoEventTypes = versionTwoEventTypesWrap.Items;
             versionTwoEventTypes.ShouldNotBeNull();
             versionTwoEventTypes.Count.ShouldBe(1);
             versionTwoEventTypes[0].Version.ShouldBe(allEventTypes[1].Version);

--- a/test/CheckoutSdkTest/FourStaticKeysSdkCredentialsTest.cs
+++ b/test/CheckoutSdkTest/FourStaticKeysSdkCredentialsTest.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Net.Http.Headers;
 using Checkout.Four;
 using Shouldly;
+using System;
 using Xunit;
 using Xunit.Sdk;
 

--- a/test/CheckoutSdkTest/Instruments/Four/InstrumentsClientTest.cs
+++ b/test/CheckoutSdkTest/Instruments/Four/InstrumentsClientTest.cs
@@ -92,9 +92,9 @@ namespace Checkout.Instruments.Four
         private async Task ShouldDeleteInstrument()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Delete<object>("instruments/instrument_id", _authorization,
+                    apiClient.Delete<EmptyResponse>("instruments/instrument_id", _authorization,
                         CancellationToken.None))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IInstrumentsClient client =
                 new InstrumentsClient(_apiClient.Object, _configuration.Object);

--- a/test/CheckoutSdkTest/Instruments/Four/InstrumentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Instruments/Four/InstrumentsIntegrationTest.cs
@@ -57,6 +57,9 @@ namespace Checkout.Instruments.Four
                 await FourApi.InstrumentsClient().Update(tokenInstrument.Id, updateInstrumentTokenRequest);
 
             updateResponse.ShouldNotBeNull();
+            updateResponse.HttpStatusCode.ShouldNotBeNull();
+            updateResponse.ResponseHeaders.ShouldNotBeNull();
+            updateResponse.Body.ShouldNotBeNull();
 
             var updateCardInstrumentResponse = (UpdateCardInstrumentResponse)updateResponse;
             updateCardInstrumentResponse.Fingerprint.ShouldNotBeNull();
@@ -119,7 +122,10 @@ namespace Checkout.Instruments.Four
             var tokenInstrument = await CreateTokenInstrument();
             tokenInstrument.ShouldNotBeNull();
 
-            await FourApi.InstrumentsClient().Delete(tokenInstrument.Id);
+            var emptyResponse = await FourApi.InstrumentsClient().Delete(tokenInstrument.Id);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             await AssertNotFound(FourApi.InstrumentsClient().Get(tokenInstrument.Id));
         }

--- a/test/CheckoutSdkTest/Instruments/InstrumentsClientTest.cs
+++ b/test/CheckoutSdkTest/Instruments/InstrumentsClientTest.cs
@@ -1,7 +1,7 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Instruments
@@ -84,9 +84,9 @@ namespace Checkout.Instruments
         private async Task ShouldDeleteInstrument()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Delete<object>("instruments/instrument_id", _authorization,
+                    apiClient.Delete<EmptyResponse>("instruments/instrument_id", _authorization,
                         CancellationToken.None))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IInstrumentsClient client = new InstrumentsClient(_apiClient.Object, _configuration.Object);
 

--- a/test/CheckoutSdkTest/Instruments/InstrumentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Instruments/InstrumentsIntegrationTest.cs
@@ -1,7 +1,7 @@
-using System.Threading.Tasks;
 using Checkout.Common;
 using Checkout.Tokens;
 using Shouldly;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Instruments
@@ -74,7 +74,11 @@ namespace Checkout.Instruments
                 ExpiryYear = 2026,
             };
 
-            await DefaultApi.InstrumentsClient().Update(createInstrumentResponse.Id, updateInstrumentRequest);
+            var update = await DefaultApi.InstrumentsClient().Update(createInstrumentResponse.Id, updateInstrumentRequest);
+            update.ShouldNotBeNull();
+            update.HttpStatusCode.ShouldNotBeNull();
+            update.ResponseHeaders.ShouldNotBeNull();
+            update.Body.ShouldNotBeNull();
 
             var retrieveInstrumentResponse = await DefaultApi.InstrumentsClient().Get(createInstrumentResponse.Id);
             retrieveInstrumentResponse.ShouldNotBeNull();
@@ -88,7 +92,10 @@ namespace Checkout.Instruments
         {
             var createInstrumentResponse = await CreateTokenInstrument();
 
-            await DefaultApi.InstrumentsClient().Delete(createInstrumentResponse.Id);
+            var emptyResponse = await DefaultApi.InstrumentsClient().Delete(createInstrumentResponse.Id);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             await AssertNotFound(DefaultApi.InstrumentsClient().Get(createInstrumentResponse.Id));
         }

--- a/test/CheckoutSdkTest/Marketplace/MarketplaceClientTest.cs
+++ b/test/CheckoutSdkTest/Marketplace/MarketplaceClientTest.cs
@@ -97,13 +97,13 @@ namespace Checkout.Marketplace
         {
             _apiClient
                 .Setup(x =>
-                    x.Post<object>(
+                    x.Post<EmptyResponse>(
                         "marketplace/entities/entity_id/instruments",
                         It.IsAny<SdkAuthorization>(),
                         It.IsAny<object>(),
                         It.IsAny<CancellationToken>(),
                         It.IsAny<string>()))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             var response = await _marketplaceClient.CreatePaymentInstrument(
                 "entity_id",
@@ -177,11 +177,11 @@ namespace Checkout.Marketplace
         [Fact]
         private async Task ShouldUpdatePayoutSchedule()
         {
-            var responseAsync = new VoidResponse();
+            var responseAsync = new EmptyResponse();
 
             _apiClient
                 .Setup(x =>
-                    x.Put<VoidResponse>(
+                    x.Put<EmptyResponse>(
                         "marketplace/entities/entity_id/payout-schedules",
                         It.IsAny<SdkAuthorization>(),
                         It.IsAny<object>(),

--- a/test/CheckoutSdkTest/Marketplace/MarketplaceIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Marketplace/MarketplaceIntegrationTest.cs
@@ -90,6 +90,8 @@ namespace Checkout.Marketplace
                 await FourApi.MarketplaceClient().UpdateEntity(entityId, onboardEntityRequest);
 
             updatedEntityResponse.ShouldNotBeNull();
+            updatedEntityResponse.HttpStatusCode.ShouldNotBeNull();
+            updatedEntityResponse.ResponseHeaders.ShouldNotBeNull();
 
             OnboardEntityDetailsResponse verifyUpdated = await FourApi.MarketplaceClient().GetEntity(entityId);
 

--- a/test/CheckoutSdkTest/Marketplace/MarketplacePayoutSchedulesIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Marketplace/MarketplacePayoutSchedulesIntegrationTest.cs
@@ -20,8 +20,11 @@ namespace Checkout.Marketplace
                 Recurrence = new ScheduleFrequencyWeeklyRequest {ByDay = DaySchedule.Sunday}
             };
 
-            await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
+            var emptyResponse = await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
                 .UpdatePayoutSchedule("ent_sdioy6bajpzxyl3utftdp7legq", Currency.USD, scheduleRequest);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             var response = await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
                 .RetrievePayoutSchedule("ent_sdioy6bajpzxyl3utftdp7legq");
@@ -43,8 +46,11 @@ namespace Checkout.Marketplace
                 Enabled = true, Threshold = 1000, Recurrence = new ScheduleFrequencyDailyRequest()
             };
 
-            await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
+            var emptyResponse = await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
                 .UpdatePayoutSchedule("ent_sdioy6bajpzxyl3utftdp7legq", Currency.USD, scheduleRequest);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             var response = await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
                 .RetrievePayoutSchedule("ent_sdioy6bajpzxyl3utftdp7legq");
@@ -68,8 +74,11 @@ namespace Checkout.Marketplace
                 Recurrence = new ScheduleFrequencyMonthlyRequest {ByMonthDay = 3}
             };
 
-            await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
+            var emptyResponse = await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
                 .UpdatePayoutSchedule("ent_sdioy6bajpzxyl3utftdp7legq", Currency.USD, scheduleRequest);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             var response = await GetPayoutSchedulesCheckoutApi().MarketplaceClient()
                 .RetrievePayoutSchedule("ent_sdioy6bajpzxyl3utftdp7legq");

--- a/test/CheckoutSdkTest/OAuthIntegrationTest.cs
+++ b/test/CheckoutSdkTest/OAuthIntegrationTest.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Threading.Tasks;
 using Checkout.Common;
 using Checkout.Payments.Four.Request;
 using Checkout.Payments.Four.Request.Source;
 using Checkout.Payments.Four.Sender;
 using Shouldly;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
 

--- a/test/CheckoutSdkTest/Payments/Four/PaymentActionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Four/PaymentActionsIntegrationTest.cs
@@ -1,5 +1,4 @@
 using Shouldly;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -15,10 +14,10 @@ namespace Checkout.Payments.Four
             var actions = await Retriable(async () =>
                 await FourApi.PaymentsClient().GetPaymentActions(paymentResponse.Id), ThereAreTwoPaymentActions);
 
-            actions.ShouldNotBeNull();
-            actions.Count.ShouldBe(2);
+            actions.Items.ShouldNotBeNull();
+            actions.Items.Count.ShouldBe(2);
 
-            foreach (var paymentAction in actions)
+            foreach (var paymentAction in actions.Items)
             {
                 paymentAction.Amount.ShouldBe(10);
                 paymentAction.Approved.ShouldBe(true);
@@ -30,9 +29,9 @@ namespace Checkout.Payments.Four
             }
         }
 
-        private static bool ThereAreTwoPaymentActions(IList<PaymentAction> obj)
+        private static bool ThereAreTwoPaymentActions(ItemsResponse<PaymentAction> obj)
         {
-            return obj.Count == 2;
+            return obj.Items.Count == 2;
         }
     }
 }

--- a/test/CheckoutSdkTest/Payments/Four/PaymentsClientTest.cs
+++ b/test/CheckoutSdkTest/Payments/Four/PaymentsClientTest.cs
@@ -224,10 +224,10 @@ namespace Checkout.Payments.Four
         [Fact]
         private async Task ShouldGetPaymentActions()
         {
-            var paymentActions = new List<PaymentAction> {new PaymentAction(), new PaymentAction()};
+            var paymentActions = new ItemsResponse<PaymentAction>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Get<IList<PaymentAction>>(PaymentsPath + "/payment_id/actions", _authorization,
+                    apiClient.Get<ItemsResponse<PaymentAction>>(PaymentsPath + "/payment_id/actions", _authorization,
                         CancellationToken.None))
                 .ReturnsAsync(() => paymentActions);
 

--- a/test/CheckoutSdkTest/Payments/Four/RequestPaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Four/RequestPaymentsIntegrationTest.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Threading.Tasks;
 using Checkout.Common;
 using Checkout.Payments.Four.Request;
 using Checkout.Payments.Four.Request.Source;
 using Checkout.Payments.Four.Response.Source;
 using Shouldly;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Payments.Four

--- a/test/CheckoutSdkTest/Payments/Links/PaymentLinksClientTest.cs
+++ b/test/CheckoutSdkTest/Payments/Links/PaymentLinksClientTest.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using Shouldly;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -32,7 +33,7 @@ namespace Checkout.Payments.Links
             PaymentLinkResponse paymentLinkResponse = new PaymentLinkResponse
             {
                 Id = "1",
-                ExpiresOn = System.DateTime.Now,
+                ExpiresOn = DateTime.Now,
                 Reference = "ref1234"
             };
 
@@ -57,7 +58,7 @@ namespace Checkout.Payments.Links
             PaymentLinkResponse paymentLinkResponse = new PaymentLinkResponse
             {
                 Id = "1",
-                ExpiresOn = System.DateTime.Now,
+                ExpiresOn = DateTime.Now,
                 Reference = "ref1234"
             };
 
@@ -88,7 +89,7 @@ namespace Checkout.Payments.Links
             var paymentLinkDetailsResponse = new PaymentLinkDetailsResponse()
             {
                 Id = "1",
-                ExpiresOn = System.DateTime.Now,
+                ExpiresOn = DateTime.Now,
                 Description = "Test",
                 ReturnUrl = "test.com",
                 Reference = reference

--- a/test/CheckoutSdkTest/Payments/Links/PaymentLinksIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Links/PaymentLinksIntegrationTest.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Threading.Tasks;
-using Checkout.Common;
+﻿using Checkout.Common;
 using Shouldly;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Payments.Links

--- a/test/CheckoutSdkTest/Payments/PaymentActionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/PaymentActionsIntegrationTest.cs
@@ -1,5 +1,4 @@
 using Shouldly;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,9 +11,9 @@ namespace Checkout.Payments
         {
             var paymentResponse = await MakeCardPayment(true);
 
-            var actions = await Retriable(async () =>
+            var actionsWrapper = await Retriable(async () =>
                 await DefaultApi.PaymentsClient().GetPaymentActions(paymentResponse.Id), ThereAreTwoPaymentActions);
-
+            var actions = actionsWrapper.Items;
             actions.ShouldNotBeNull();
             actions.Count.ShouldBe(2);
 
@@ -31,9 +30,9 @@ namespace Checkout.Payments
             }
         }
 
-        private static bool ThereAreTwoPaymentActions(IList<PaymentAction> obj)
+        private static bool ThereAreTwoPaymentActions(ItemsResponse<PaymentAction> obj)
         {
-            return obj.Count == 2;
+            return obj.Items.Count == 2;
         }
     }
 }

--- a/test/CheckoutSdkTest/Payments/PaymentsClientTest.cs
+++ b/test/CheckoutSdkTest/Payments/PaymentsClientTest.cs
@@ -4,7 +4,6 @@ using Checkout.Payments.Request.Source;
 using Checkout.Payments.Response;
 using Moq;
 using Shouldly;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -163,10 +162,10 @@ namespace Checkout.Payments
         [Fact]
         private async Task ShouldGetPaymentActions()
         {
-            var paymentActions = new List<PaymentAction> {new PaymentAction(), new PaymentAction()};
+            var paymentActions = new ItemsResponse<PaymentAction>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Get<IList<PaymentAction>>(PaymentsPath + "/payment_id/actions", _authorization,
+                    apiClient.Get<ItemsResponse<PaymentAction>>(PaymentsPath + "/payment_id/actions", _authorization,
                         CancellationToken.None))
                 .ReturnsAsync(() => paymentActions);
 

--- a/test/CheckoutSdkTest/Reconciliation/ReconciliationClientTest.cs
+++ b/test/CheckoutSdkTest/Reconciliation/ReconciliationClientTest.cs
@@ -112,28 +112,28 @@ namespace Checkout.Reconciliation
             var request = new QueryFilterDateRange {To = _to, From = _from};
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Query<string>("reporting/payments/download", _authorization, request,
+                    apiClient.Query<ContentsResponse>("reporting/payments/download", _authorization, request,
                         CancellationToken.None))
-                .ReturnsAsync(() => Csv);
+                .ReturnsAsync(() => new ContentsResponse {Content = Csv});
 
             var response = await _reconciliationClient.RetrieveCsvPaymentReport(request);
 
             response.ShouldNotBeNull();
-            response.ShouldBe(Csv);
+            response.Content.ShouldBe(Csv);
         }
 
         [Fact]
         private async Task ShouldRetrieveCsvSingleStatementReport()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Query<string>("reporting/statements/id/payments/download", _authorization,
+                    apiClient.Query<ContentsResponse>("reporting/statements/id/payments/download", _authorization,
                         It.IsAny<QueryFilterDateRange>(),
                         CancellationToken.None))
-                .ReturnsAsync(() => Csv);
+                .ReturnsAsync(() => new ContentsResponse {Content = Csv});
 
             var response = await _reconciliationClient.RetrieveCsvSingleStatementReport("id");
             response.ShouldNotBeNull();
-            response.ShouldBe(Csv);
+            response.Content.ShouldBe(Csv);
         }
 
         [Fact]
@@ -142,14 +142,14 @@ namespace Checkout.Reconciliation
             var request = new QueryFilterDateRange {To = _to, From = _from};
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Query<string>("reporting/statements/download", _authorization, request,
+                    apiClient.Query<ContentsResponse>("reporting/statements/download", _authorization, request,
                         CancellationToken.None))
-                .ReturnsAsync(() => Csv);
+                .ReturnsAsync(() => new ContentsResponse {Content = Csv});
 
             var response = await _reconciliationClient.RetrieveCsvStatementsReport(request);
 
             response.ShouldNotBeNull();
-            response.ShouldBe(Csv);
+            response.Content.ShouldBe(Csv);
         }
     }
 }

--- a/test/CheckoutSdkTest/Reconciliation/ReconciliationIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Reconciliation/ReconciliationIntegrationTest.cs
@@ -59,7 +59,7 @@ namespace Checkout.Reconciliation
         {
             var response = await _productionApi.ReconciliationClient().RetrieveCsvPaymentReport(_queryFilterDateRange);
             response.ShouldNotBeNull();
-            response.ShouldNotBeEmpty();
+            response.Content.ShouldNotBeEmpty();
         }
 
         [Fact(Skip = "Only works in Production")]
@@ -68,7 +68,7 @@ namespace Checkout.Reconciliation
             var response = await _productionApi.ReconciliationClient()
                 .RetrieveCsvSingleStatementReport("reference");
             response.ShouldNotBeNull();
-            response.ShouldNotBeEmpty();
+            response.Content.ShouldNotBeEmpty();
         }
 
         [Fact(Skip = "Only works in Production")]
@@ -77,7 +77,7 @@ namespace Checkout.Reconciliation
             var response = await _productionApi.ReconciliationClient()
                 .RetrieveCsvStatementsReport(_queryFilterDateRange);
             response.ShouldNotBeNull();
-            response.ShouldNotBeEmpty();
+            response.Content.ShouldNotBeEmpty();
         }
     }
 }

--- a/test/CheckoutSdkTest/Risk/Four/RiskIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Risk/Four/RiskIntegrationTest.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Checkout.Common;
 using Checkout.Risk.PreAuthentication;
 using Checkout.Risk.PreCapture;
 using Checkout.Risk.source;
 using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
-using CustomerRequest = Checkout.Customers.CustomerRequest;
+using CustomerRequest = Checkout.Customers.Four.CustomerRequest;
 
 namespace Checkout.Risk.Four
 {
@@ -48,7 +48,7 @@ namespace Checkout.Risk.Four
         [Fact]
         private async Task ShouldRiskCustomerSource()
         {
-            var customerRequest = new Customers.Four.CustomerRequest()
+            var customerRequest = new CustomerRequest()
             {
                 Email = GenerateRandomEmail(),
                 Name = "Customer"

--- a/test/CheckoutSdkTest/Risk/RiskClientTest.cs
+++ b/test/CheckoutSdkTest/Risk/RiskClientTest.cs
@@ -1,9 +1,9 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Checkout.Risk.PreAuthentication;
 using Checkout.Risk.PreCapture;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Risk

--- a/test/CheckoutSdkTest/Risk/RiskIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Risk/RiskIntegrationTest.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Checkout.Common;
 using Checkout.Risk.PreAuthentication;
 using Checkout.Risk.PreCapture;
 using Checkout.Risk.source;
 using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 using CustomerRequest = Checkout.Customers.CustomerRequest;
 

--- a/test/CheckoutSdkTest/Sessions/SessionsClientTest.cs
+++ b/test/CheckoutSdkTest/Sessions/SessionsClientTest.cs
@@ -69,7 +69,7 @@ namespace Checkout.Sessions
             };
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<Resource>(Sessions,
+                    apiClient.Post<HttpMetadata>(Sessions,
                         _sdkCredentials.Object.GetSdkAuthorization(SdkAuthorizationType.OAuth),
                         SessionResponseMappings, request,
                         CancellationToken.None, null))
@@ -100,7 +100,7 @@ namespace Checkout.Sessions
             };
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<Resource>(Sessions,
+                    apiClient.Post<HttpMetadata>(Sessions,
                         _sdkCredentials.Object.GetSdkAuthorization(SdkAuthorizationType.OAuth),
                         SessionResponseMappings, request,
                         CancellationToken.None, null))
@@ -331,9 +331,9 @@ namespace Checkout.Sessions
             var response = new Mock<GetSessionResponse>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<object>($"{Sessions}/id/{Complete}", _authorization, null,
+                    apiClient.Post<EmptyResponse>($"{Sessions}/id/{Complete}", _authorization, null,
                         CancellationToken.None, null))
-                .ReturnsAsync(() => response.Object);
+                .ReturnsAsync(() => new EmptyResponse());
 
             _sessionsClient = new SessionsClient(_apiClient.Object, _configuration.Object);
 
@@ -348,9 +348,9 @@ namespace Checkout.Sessions
             var response = new Mock<GetSessionResponse>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<object>($"{Sessions}/id/{Complete}", SessionSecretAuthorization, null,
+                    apiClient.Post<EmptyResponse>($"{Sessions}/id/{Complete}", SessionSecretAuthorization, null,
                         CancellationToken.None, null))
-                .ReturnsAsync(() => response.Object);
+                .ReturnsAsync(() => new EmptyResponse());
 
             _sessionsClient = new SessionsClient(_apiClient.Object, _configuration.Object);
 

--- a/test/CheckoutSdkTest/Sessions/UpdateSessionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Sessions/UpdateSessionsIntegrationTest.cs
@@ -39,6 +39,8 @@ namespace Checkout.Sessions
                 : await FourApi.SessionsClient().UpdateSession(created.Id, BrowserSession(), CancellationToken.None);
 
             updated.ShouldNotBeNull();
+            updated.HttpStatusCode.ShouldNotBeNull();
+            updated.ResponseHeaders.ShouldNotBeNull();
             updated.Id.ShouldNotBeNull();
 
             if (usingSessionSecret)
@@ -127,6 +129,8 @@ namespace Checkout.Sessions
                     threeDsMethodCompletionRequest, CancellationToken.None);
 
             updated.ShouldNotBeNull();
+            updated.HttpStatusCode.ShouldNotBeNull();
+            updated.ResponseHeaders.ShouldNotBeNull();
         }
     }
 }

--- a/test/CheckoutSdkTest/Sources/SourcesClientTest.cs
+++ b/test/CheckoutSdkTest/Sources/SourcesClientTest.cs
@@ -1,7 +1,7 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Sources

--- a/test/CheckoutSdkTest/Sources/SourcesTestIntegration.cs
+++ b/test/CheckoutSdkTest/Sources/SourcesTestIntegration.cs
@@ -1,6 +1,6 @@
-using System.Threading.Tasks;
 using Checkout.Common;
 using Shouldly;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Sources

--- a/test/CheckoutSdkTest/Webhooks/WebhookClientTest.cs
+++ b/test/CheckoutSdkTest/Webhooks/WebhookClientTest.cs
@@ -1,8 +1,7 @@
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Moq;
 using Shouldly;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Checkout.Webhooks
@@ -27,13 +26,10 @@ namespace Checkout.Webhooks
         [Fact]
         private async Task ShouldRetrieveWebhooks()
         {
-            var webhookResponses = new List<WebhookResponse>
-            {
-                new WebhookResponse()
-            };
+            var webhookResponses = new ItemsResponse<WebhookResponse>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Get<IList<WebhookResponse>>("webhooks", _authorization,
+                    apiClient.Get<ItemsResponse<WebhookResponse>>("webhooks", _authorization,
                         CancellationToken.None))
                 .ReturnsAsync(() => webhookResponses);
 
@@ -126,9 +122,9 @@ namespace Checkout.Webhooks
         private async Task ShouldRemoveWebhook()
         {
             _apiClient.Setup(apiClient =>
-                    apiClient.Delete<object>("webhooks/wh_kve4kqtq3ueezaxriev666j4ky", _authorization,
+                    apiClient.Delete<EmptyResponse>("webhooks/wh_kve4kqtq3ueezaxriev666j4ky", _authorization,
                         CancellationToken.None))
-                .ReturnsAsync(() => new object());
+                .ReturnsAsync(() => new EmptyResponse());
 
             IWebhooksClient client = new WebhooksClient(_apiClient.Object, _configuration.Object);
 

--- a/test/CheckoutSdkTest/Workflows/Four/WorkflowEventsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Workflows/Four/WorkflowEventsIntegrationTest.cs
@@ -1,7 +1,6 @@
 ﻿using Checkout.Payments.Four.Response;
 using Checkout.Workflows.Four.Events;
 using Shouldly;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -13,8 +12,9 @@ namespace Checkout.Workflows.Four
         [Fact]
         public async Task ShouldGetEventTypes()
         {
-            IList<EventTypesResponse> eventTypesResponses = await FourApi.WorkflowsClient().GetEventTypes();
+            ItemsResponse<EventTypesResponse> eventTypesResponsesWrapper = await FourApi.WorkflowsClient().GetEventTypes();
 
+            var eventTypesResponses = eventTypesResponsesWrapper.Items;
             eventTypesResponses.ShouldNotBeNull();
             eventTypesResponses.Count.ShouldBe(9);
 

--- a/test/CheckoutSdkTest/Workflows/Four/WorkflowsClientTest.cs
+++ b/test/CheckoutSdkTest/Workflows/Four/WorkflowsClientTest.cs
@@ -180,10 +180,10 @@ namespace Checkout.Workflows.Four
         [Fact]
         public async Task ShouldRemoveWorkflow()
         {
-            var response = new object();
+            var response = new EmptyResponse();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Delete<object>("workflows" + "/workflow_id", _authorization, CancellationToken.None))
+                    apiClient.Delete<EmptyResponse>("workflows" + "/workflow_id", _authorization, CancellationToken.None))
                 .ReturnsAsync(() => response);
 
             IWorkflowsClient workflowsClient = new WorkflowsClient(_apiClient.Object, _configuration.Object);
@@ -213,13 +213,12 @@ namespace Checkout.Workflows.Four
         [Fact]
         public async Task ShouldUpdateWorkflowAction()
         {
-            var response = new object();
             WebhookWorkflowActionRequest workflowActionRequest = new WebhookWorkflowActionRequest();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Put<object>("workflows" + "/workflow_id/actions/action_id", _authorization,
+                    apiClient.Put<EmptyResponse>("workflows" + "/workflow_id/actions/action_id", _authorization,
                         workflowActionRequest, CancellationToken.None, null))
-                .ReturnsAsync(() => response);
+                .ReturnsAsync(() => new EmptyResponse());
 
             IWorkflowsClient workflowsClient = new WorkflowsClient(_apiClient.Object, _configuration.Object);
 
@@ -271,13 +270,12 @@ namespace Checkout.Workflows.Four
         [Fact]
         public async Task ShouldUpdateWorkflowCondition()
         {
-            var response = new object();
             EventWorkflowConditionRequest eventWorkflowConditionRequest = new EventWorkflowConditionRequest();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Put<object>("workflows" + "/workflow_id/conditions/condition_id", _authorization,
+                    apiClient.Put<EmptyResponse>("workflows" + "/workflow_id/conditions/condition_id", _authorization,
                         eventWorkflowConditionRequest, CancellationToken.None, null))
-                .ReturnsAsync(() => response);
+                .ReturnsAsync(() => new EmptyResponse());
 
             IWorkflowsClient workflowsClient = new WorkflowsClient(_apiClient.Object, _configuration.Object);
 
@@ -331,10 +329,10 @@ namespace Checkout.Workflows.Four
         [Fact]
         public async Task ShouldGetEventTypes()
         {
-            List<EventTypesResponse> response = new List<EventTypesResponse>();
+            ItemsResponse<EventTypesResponse> response = new ItemsResponse<EventTypesResponse>();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Get<IList<EventTypesResponse>>("workflows" + "/event-types", _authorization,
+                    apiClient.Get<ItemsResponse<EventTypesResponse>>("workflows" + "/event-types", _authorization,
                         CancellationToken.None))
                 .ReturnsAsync(() => response);
 

--- a/test/CheckoutSdkTest/Workflows/Four/WorkflowsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Workflows/Four/WorkflowsIntegrationTest.cs
@@ -87,6 +87,9 @@ namespace Checkout.Workflows.Four
                 await FourApi.WorkflowsClient().UpdateWorkflow(workflow.Id, request);
 
             updateWorkflowResponse.ShouldNotBeNull();
+            updateWorkflowResponse.HttpStatusCode.ShouldNotBeNull();
+            updateWorkflowResponse.ResponseHeaders.ShouldNotBeNull();
+            updateWorkflowResponse.Body.ShouldNotBeNull();
             updateWorkflowResponse.Name.ShouldBe("testing_2");
             updateWorkflowResponse.Active.ShouldBe(false);
         }
@@ -116,7 +119,10 @@ namespace Checkout.Workflows.Four
                     Signature = new WebhookSignature {Key = "8V8x0dLK%AyD*DNS8JJr", Method = "HMACSHA256"}
                 };
 
-            await FourApi.WorkflowsClient().UpdateWorkflowAction(getWorkflowResponse.Id, actionId, updateAction);
+            var emptyResponse = await FourApi.WorkflowsClient().UpdateWorkflowAction(getWorkflowResponse.Id, actionId, updateAction);
+            emptyResponse.ShouldNotBeNull();
+            emptyResponse.HttpStatusCode.ShouldNotBeNull();
+            emptyResponse.ResponseHeaders.ShouldNotBeNull();
 
             GetWorkflowResponse getWorkflowResponseUpdated =
                 await FourApi.WorkflowsClient().GetWorkflow(createdWorkflow.Id);

--- a/test/CheckoutSdkTest/Workflows/Four/WorkflowsReflowIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Workflows/Four/WorkflowsReflowIntegrationTest.cs
@@ -24,7 +24,10 @@ namespace Checkout.Workflows.Four
 
             ReflowResponse reflowResponse = await FourApi.WorkflowsClient().ReflowByEvent(paymentApprovedEvent.Id);
 
-            reflowResponse.ShouldBeNull();
+            reflowResponse.ShouldNotBeNull();
+            reflowResponse.HttpStatusCode.ShouldNotBeNull();
+            reflowResponse.ResponseHeaders.ShouldNotBeNull();
+            
         }
 
         [Fact]
@@ -37,7 +40,7 @@ namespace Checkout.Workflows.Four
             ReflowResponse reflowResponse =
                 await Retriable(async () => await FourApi.WorkflowsClient().ReflowBySubject(payment.Id));
 
-            reflowResponse.ShouldBeNull();
+            reflowResponse.ShouldNotBeNull();
         }
 
         [Fact(Skip = "unstable")]
@@ -52,7 +55,9 @@ namespace Checkout.Workflows.Four
             ReflowResponse reflowResponse = await Retriable(async () => await FourApi.WorkflowsClient()
                 .ReflowByEventAndWorkflow(paymentApprovedEvent.Id, createWorkflowResponse.Id));
 
-            reflowResponse.ShouldBeNull();
+            reflowResponse.ShouldNotBeNull();
+            reflowResponse.HttpStatusCode.ShouldNotBeNull();
+            reflowResponse.ResponseHeaders.ShouldNotBeNull();
         }
 
         [Fact]
@@ -65,7 +70,7 @@ namespace Checkout.Workflows.Four
             ReflowResponse reflowResponse = await Retriable(async () => await FourApi.WorkflowsClient()
                 .ReflowBySubjectAndWorkflow(payment.Id, createWorkflowResponse.Id));
 
-            reflowResponse.ShouldBeNull();
+            reflowResponse.ShouldNotBeNull();
         }
 
         [Fact]
@@ -85,7 +90,9 @@ namespace Checkout.Workflows.Four
 
             ReflowResponse reflowResponse = await FourApi.WorkflowsClient().Reflow(request);
 
-            reflowResponse.ShouldBeNull();
+            reflowResponse.ShouldNotBeNull();
+            reflowResponse.HttpStatusCode.ShouldNotBeNull();
+            reflowResponse.ResponseHeaders.ShouldNotBeNull();
         }
 
         [Fact]
@@ -103,7 +110,9 @@ namespace Checkout.Workflows.Four
             ReflowResponse reflowResponse =
                 await Retriable(async () => await FourApi.WorkflowsClient().Reflow(request));
 
-            reflowResponse.ShouldBeNull();
+            reflowResponse.ShouldNotBeNull();
+            reflowResponse.HttpStatusCode.ShouldNotBeNull();
+            reflowResponse.ResponseHeaders.ShouldNotBeNull();
         }
     }
 }


### PR DESCRIPTION
Refactor the SDK to provide support of Http Metadata and exposes inside responses classes, overall there are no breaking changes but here is the list to take in consideration.

- Previous `empty` responses, or `<object>` type responses, now returns an `EmptyResponse` object
- Array results on query operations now returns a wrapper `ItemsResponse`
- String responses like `CSV` contents now are inside of `ContentsResponse` wrapper.
- `VoidResponse` was deleted in favor to use EmptyResponse
- Fixed an issue on ReconciliationClient where returning `PaymentReportData` `IssuerCountry` or `MerchantCountry` could have three characters country code and were not mapped during deserializing