### PR TITLE
Action.ResponseCode type changed to string

### DIFF
--- a/src/CheckoutSdk/Reconciliation/Previous/Action.cs
+++ b/src/CheckoutSdk/Reconciliation/Previous/Action.cs
@@ -12,7 +12,7 @@ namespace Checkout.Reconciliation.Previous
 
         public DateTime? ProcessedOn { get; set; }
 
-        public long? ResponseCode { get; set; }
+        public string ResponseCode { get; set; }
 
         public string ResponseDescription { get; set; }
 


### PR DESCRIPTION
Environment

- Checkout SDK version: 4.0.4

Some reports are producing JsonSerializationException:
Newtonsoft.Json.JsonSerializationException: Error converting value "200N7" to type 'System.Nullable`1[System.Int64]'. Path 'data[41].actions[0].response_code', line 1, position 60103.

Looking at the body of the response **actions/response_code** is a string  for example:

- "response_code": "20065"
- "response_code": "**200N7**"

But in SDK it's marked as **long?** it looks like this field has to be a string.