### PR TITLE
Implement retrieve files endpoint in Platforms API

### DIFF
--- a/src/CheckoutSdk/Accounts/AccountsClient.cs
+++ b/src/CheckoutSdk/Accounts/AccountsClient.cs
@@ -15,6 +15,7 @@ namespace Checkout.Accounts
         private const string InstrumentPath = "instruments";
         private const string PayoutSchedulePath = "payout-schedules";
         private const string PaymentInstrumentsPath = "payment-instruments";
+        private const string PlatformsFilesPath = "platforms-files";
 
         public AccountsClient(
             IApiClient apiClient,
@@ -44,16 +45,6 @@ namespace Checkout.Accounts
                 cancellationToken);
         }
 
-        public async Task<PaymentInstrumentDetailsResponse> RetrievePaymentInstrumentDetails(string entityId,
-            string paymentInstrumentId, CancellationToken cancellationToken = default)
-        {
-            CheckoutUtils.ValidateParams("entityId", entityId, "paymentInstrumentId", paymentInstrumentId);
-            return await ApiClient.Get<PaymentInstrumentDetailsResponse>(
-                BuildPath(AccountsPath, EntitiesPath, entityId, PaymentInstrumentsPath, paymentInstrumentId),
-                SdkAuthorization(),
-                cancellationToken);
-        }
-
         public async Task<OnboardEntityDetailsResponse> GetEntity(string entityId,
             CancellationToken cancellationToken = default)
         {
@@ -72,6 +63,25 @@ namespace Checkout.Accounts
                 BuildPath(AccountsPath, EntitiesPath, entityId),
                 SdkAuthorization(),
                 entityRequest,
+                cancellationToken);
+        }
+        
+        public async Task<PlatformsFileUploadResponse> UploadAFile(PlatformsFileRequest fileRequest, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("fileRequest", fileRequest);
+            return await ApiClient.Post<PlatformsFileUploadResponse>(
+                BuildPath(PlatformsFilesPath),
+                SdkAuthorization(),
+                fileRequest,
+                cancellationToken);
+        }
+        
+        public async Task<PlatformsFileRetrieveResponse> RetrieveAFile(string fileId, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("fileId", fileId);
+            return await ApiClient.Get<PlatformsFileRetrieveResponse>(
+                BuildPath(PlatformsFilesPath, fileId),
+                SdkAuthorization(),
                 cancellationToken);
         }
 
@@ -97,6 +107,16 @@ namespace Checkout.Accounts
                 BuildPath(AccountsPath, EntitiesPath, entityId, PaymentInstrumentsPath),
                 SdkAuthorization(),
                 paymentInstrumentRequest,
+                cancellationToken);
+        }
+        
+        public async Task<PaymentInstrumentDetailsResponse> RetrievePaymentInstrumentDetails(string entityId,
+            string paymentInstrumentId, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("entityId", entityId, "paymentInstrumentId", paymentInstrumentId);
+            return await ApiClient.Get<PaymentInstrumentDetailsResponse>(
+                BuildPath(AccountsPath, EntitiesPath, entityId, PaymentInstrumentsPath, paymentInstrumentId),
+                SdkAuthorization(),
                 cancellationToken);
         }
 

--- a/src/CheckoutSdk/Accounts/IAccountsClient.cs
+++ b/src/CheckoutSdk/Accounts/IAccountsClient.cs
@@ -9,17 +9,13 @@ namespace Checkout.Accounts
 {
     public interface IAccountsClient
     {
+        [Obsolete("This endpoint is no longer supported officially, please check the documentation.", false)]
         Task<IdResponse> SubmitFile(
             AccountsFileRequest accountsFileRequest,
             CancellationToken cancellationToken = default);
-
+        
         Task<OnboardEntityResponse> CreateEntity(
             OnboardEntityRequest entityRequest,
-            CancellationToken cancellationToken = default);
-
-        Task<PaymentInstrumentDetailsResponse> RetrievePaymentInstrumentDetails(
-            string entityId,
-            string paymentInstrumentId,
             CancellationToken cancellationToken = default);
 
         Task<OnboardEntityDetailsResponse> GetEntity(
@@ -29,6 +25,14 @@ namespace Checkout.Accounts
         Task<OnboardEntityResponse> UpdateEntity(
             string entityId,
             OnboardEntityRequest entityRequest,
+            CancellationToken cancellationToken = default);
+        
+        Task<PlatformsFileUploadResponse> UploadAFile(
+            PlatformsFileRequest fileRequest,
+            CancellationToken cancellationToken = default);
+
+        Task<PlatformsFileRetrieveResponse> RetrieveAFile(
+            string fileId, 
             CancellationToken cancellationToken = default);
 
         [Obsolete("Use CreatePaymentInstrument for PaymentInstrumentRequest instead", false)]
@@ -40,6 +44,11 @@ namespace Checkout.Accounts
         Task<IdResponse> CreatePaymentInstrument(
             string entityId,
             PaymentInstrumentRequest paymentInstrumentRequest,
+            CancellationToken cancellationToken = default);
+        
+        Task<PaymentInstrumentDetailsResponse> RetrievePaymentInstrumentDetails(
+            string entityId,
+            string paymentInstrumentId,
             CancellationToken cancellationToken = default);
 
         Task<IdResponse> UpdatePaymentInstrument(

--- a/src/CheckoutSdk/Accounts/PlatformsFileRequest.cs
+++ b/src/CheckoutSdk/Accounts/PlatformsFileRequest.cs
@@ -1,0 +1,8 @@
+namespace Checkout.Accounts
+{
+    public class PlatformsFileRequest
+    {
+        public string Purpose { get; set; }
+        public string EntityId { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Accounts/PlatformsFileRetrieveResponse.cs
+++ b/src/CheckoutSdk/Accounts/PlatformsFileRetrieveResponse.cs
@@ -1,0 +1,17 @@
+using Checkout.Common;
+using System.Collections.Generic;
+
+namespace Checkout.Accounts
+{
+    public class PlatformsFileRetrieveResponse : Resource
+    {
+        public string Id { get; set; }
+        public string Status { get; set; }
+        public IList<string> StatusReasons { get; set; }
+        public string FileName { get; set; }
+        public int Size { get; set; }
+        public string MimeType { get; set; }
+        public string UploadedOn { get; set; }
+        public string Purpose { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Accounts/PlatformsFileUploadResponse.cs
+++ b/src/CheckoutSdk/Accounts/PlatformsFileUploadResponse.cs
@@ -1,0 +1,13 @@
+using Checkout.Common;
+using System.Collections.Generic;
+
+namespace Checkout.Accounts
+{
+    public class PlatformsFileUploadResponse : Resource
+    {
+        public string Id { get; set; }
+        public string Status { get; set; }
+        public int MaximumSizeInBytes { get; set; }
+        public IList<string> DocumentTypesForPurpose { get; set; }
+    }
+}


### PR DESCRIPTION
## Implement retrieve files endpoint in Platforms API
Add:
- Upload A File endpoint
- Retrieve A File endpoint

![image](https://user-images.githubusercontent.com/2817124/219415592-1d43eb47-09f4-42c4-bc21-b2d4cf8c8930.png)

Labeled as obsolete:
- SubmitFile method

## API reference
- https://api-reference.checkout.com/#operation/uploadAFile
- https://api-reference.checkout.com/#operation/retrieveAFile

### Notice: `PUT` not implemented
https://www.checkout.com/docs/platforms/onboarding/api/full/upload-a-file#Types_of_identification_and_requirements_1