### PR TITLE
Fixed PayoutsTransactionsType FastFounds to FastFunds

### DIFF
--- a/src/CheckoutSdk/Metadata/Card/PayoutsTransactionsType.cs
+++ b/src/CheckoutSdk/Metadata/Card/PayoutsTransactionsType.cs
@@ -6,7 +6,7 @@ namespace Checkout.Metadata.Card
     {
         [EnumMember(Value = "not_supported")] NotSupported,
         [EnumMember(Value = "standard")] Standard,
-        [EnumMember(Value = "fast_founds")] FastFounds,
+        [EnumMember(Value = "fast_funds")] FastFunds,
         [EnumMember(Value = "unknown")] Unknown,
     }
 }


### PR DESCRIPTION
The PayoutsTransactionsType enum has an incorrect value. It should be FastFunds ("fast_funds"), but instead it is FastFounds ("fast_founds").