### PR TITLE
fix: Add missing support for disallowed_payment_methods when creating…

### DIFF
--- a/src/CheckoutSdk/Payments/Links/PaymentLinkRequest.cs
+++ b/src/CheckoutSdk/Payments/Links/PaymentLinkRequest.cs
@@ -51,6 +51,8 @@ namespace Checkout.Payments.Links
 
         public IList<PaymentSourceType> AllowPaymentMethods { get; set; }
 
+        public IList<PaymentSourceType> DisallowedPaymentMethods { get; set; }
+
         //Not available on Previous
 
         public string ProcessingChannelId { get; set; }


### PR DESCRIPTION
… a payment link.

Documentation for creating payment links expresses the ability to use `disallowed_payment_links` to restrict which payment links are made available to a customer using Payment Links/Hosted Pages. This is not currently supported in the current version of the SDK.

https://api-reference.checkout.com/#operation/createAPaymentLinkSession

This is a small change to add this in. This is a blocker for me, as I need to disable Google Pay on an integration with Payment Links.