### PR TITLE
Add Missing Document Types

### DIFF
--- a/src/CheckoutSdk/Accounts/Entities/Common/Documents/Documents.cs
+++ b/src/CheckoutSdk/Accounts/Entities/Common/Documents/Documents.cs
@@ -34,6 +34,12 @@ namespace Checkout.Accounts.Entities.Common.Documents
         
         public TaxVerification TaxVerification { get; set; }
         
+        // EEA Sole Trader (3.0) Representatives
+        
+        public ProofOfResidentialAddress ProofOfResidentialAddress { get; set; }
+        
+        public ProofOfRegistration ProofOfRegistration { get; set; }
+        
         // Unknown
         
         public FinancialVerification FinancialVerification { get; set; }

--- a/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfRegistration.cs
+++ b/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfRegistration.cs
@@ -1,0 +1,9 @@
+namespace Checkout.Accounts.Entities.Common.Documents
+{
+    public class ProofOfRegistration
+    {
+        public ProofOfRegistrationType? Type { get; set; }
+
+        public string Front { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfRegistrationType.cs
+++ b/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfRegistrationType.cs
@@ -1,0 +1,10 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Accounts.Entities.Common.Documents
+{
+    public enum ProofOfRegistrationType
+    {
+        [EnumMember(Value = "extract_from_trade_register")] ExtractFromTradeRegister,
+        [EnumMember(Value = "other")] Other
+    }
+}

--- a/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfResidentialAddress.cs
+++ b/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfResidentialAddress.cs
@@ -1,0 +1,9 @@
+namespace Checkout.Accounts.Entities.Common.Documents
+{
+    public class ProofOfResidentialAddress
+    {
+        public ProofOfResidentialAddressType? Type { get; set; }
+
+        public string Front { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfResidentialAddressType.cs
+++ b/src/CheckoutSdk/Accounts/Entities/Common/Documents/ProofOfResidentialAddressType.cs
@@ -1,0 +1,9 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Accounts.Entities.Common.Documents
+{
+    public enum ProofOfResidentialAddressType
+    {
+        [EnumMember(Value = "proof_of_address")] ProofOfAddress
+    }
+}


### PR DESCRIPTION
# Add Missing Document Types

### Description:
This PR introduces support for additional document types in the Checkout.com SDK, improving coverage for specific compliance and verification scenarios.

---

### Key Changes:

#### **`Documents.cs`**
- Added two new document properties for EEA Sole Trader (3.0) representatives:
  - `ProofOfResidentialAddress`
  - `ProofOfRegistration`

#### **`ProofOfRegistration.cs`**
- Added a new document class:
  - **Properties:**
    - `Type`: Specifies the type of proof (e.g., trade register extract).
    - `Front`: Stores the document data.

#### **`ProofOfRegistrationType.cs`**
- Defined an enum for `ProofOfRegistration` types:
  - `ExtractFromTradeRegister`
  - `Other`

#### **`ProofOfResidentialAddress.cs`**
- Added a new document class:
  - **Properties:**
    - `Type`: Specifies the type of residential address proof.
    - `Front`: Stores the document data.

#### **`ProofOfResidentialAddressType.cs`**
- Defined an enum for `ProofOfResidentialAddress` types:
  - `ProofOfAddress`

---

### Impact:
- **Improved Compliance:** Supports additional document types required for EEA Sole Trader verifications.
- **Expanded Use Cases:** Enables better handling of regional and compliance-specific document verification workflows.

---

### Additional Notes:
- These changes align with the latest compliance updates for EEA verification.
- The new fields and enums are backward compatible and optional.