### PR TITLE
Fix Ubuntu Version in Release Action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - id: setup-net-2_0-3_1-5_0


### PR DESCRIPTION
# Fix Ubuntu Version in Release Action

### Description:
This PR updates the `build-release.yml` GitHub Actions workflow to use a specific Ubuntu version (`ubuntu-22.04`) instead of the generic `ubuntu-latest` for improved stability and reproducibility.

---

### Key Change:
- Updated the `runs-on` configuration in the release action:
  - **Before:** `runs-on: ubuntu-latest`
  - **After:** `runs-on: ubuntu-22.04`

---

### Impact:
- **Stability:** Ensures consistent build environments by locking the Ubuntu version.
- **Predictability:** Prevents unexpected changes caused by updates to the `ubuntu-latest` tag.
- **Compatibility:** Aligns with recommended practices for long-term builds.

---

### Additional Notes:
- This change is minimal and backward compatible.
- No additional steps or dependencies are introduced.