### PR TITLE
Compatibility with .NET 4.5 using Newtonsoft.Json 12.0.3 and retain 13.0.3 for newer frameworks

### DIFF
--- a/src/CheckoutSdk/CheckoutSdk.csproj
+++ b/src/CheckoutSdk/CheckoutSdk.csproj
@@ -24,8 +24,15 @@
 
   <ItemGroup Label="Global Package References">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="[9.0.1,13.0.3]" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup Label="NET Standard Package References" Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netcoreapp3.1'">


### PR DESCRIPTION
# Compatibility with .NET 4.5 using Newtonsoft.Json 12.0.3 and retain 13.0.3 for newer frameworks
### Key Changes
This PR updates the .csproj file to ensure proper compatibility across all target frameworks by conditionally referencing different versions of Newtonsoft.Json:
- Newtonsoft.Json 12.0.3 for .NET 4.5 (as newer versions dropped support).
- Newtonsoft.Json 13.0.3 for .NET 5, .NET 6, and .NET Standard 2.0.

#### Changes
- Added a conditional <PackageReference> to use 12.0.3 only for .NET 4.5.
- Ensured that all other frameworks continue to use Newtonsoft.Json 13.0.3.

#### Why this change?
- Newtonsoft.Json 13.0.3 is not compatible with .NET 4.5, causing potential build issues.
- This change ensures legacy support for .NET 4.5 while keeping latest features for modern frameworks.

#### Impact
- No breaking changes for .NET 5, .NET 6, or .NET Standard 2.0 users.
- .NET 4.5 applications can continue functioning with Newtonsoft.Json 12.0.3.

#### Testing
- Built and validated the project for all target frameworks.
- Verified .NET 4.5 builds correctly using Newtonsoft.Json 12.0.3.
- Checked that .NET 5, .NET 6, and .NET Standard 2.0 still use Newtonsoft.Json 13.0.3.