### PR TITLE
Add retry configuration for payment requests with Dunning and Downtime classes

### DIFF
--- a/src/CheckoutSdk/Payments/Downtime.cs
+++ b/src/CheckoutSdk/Payments/Downtime.cs
@@ -1,0 +1,11 @@
+namespace Checkout.Payments
+{
+    public class Downtime
+    {
+        /// <summary>
+        /// Indicates if Checkout.com retries the payment when it's declined due to issuer or acquirer downtime
+        /// (Required)
+        /// </summary>
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Payments/Dunning.cs
+++ b/src/CheckoutSdk/Payments/Dunning.cs
@@ -1,0 +1,16 @@
+namespace Checkout.Payments
+{
+    public class Dunning
+    {
+        /// <summary>
+        /// Indicates if Checkout.com retries the payment when it's declined with a supported decline code (Required)
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary> (Optional, [ 1 .. 15 ], default: 6) </summary>
+        public int? MaxAttempts { get; set; } = 6;
+
+        /// <summary> (Optional, [ 1 .. 60 ] default: 30) </summary>
+        public int? EndAfterDays { get; set; } = 30;
+    }
+}

--- a/src/CheckoutSdk/Payments/Request/PaymentRequest.cs
+++ b/src/CheckoutSdk/Payments/Request/PaymentRequest.cs
@@ -72,7 +72,7 @@ namespace Checkout.Payments.Request
 
         public IList<Product> Items { get; set; }
 
-        public PaymentRetryRequest Retry { get; set; }
+        public RetryRequest Retry { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
         

--- a/src/CheckoutSdk/Payments/RetryRequest.cs
+++ b/src/CheckoutSdk/Payments/RetryRequest.cs
@@ -1,0 +1,11 @@
+namespace Checkout.Payments
+{
+    public class RetryRequest
+    {
+        /// <summary> Configuration of asynchronous Dunning retries (Optional) </summary>
+        public Dunning Dunning { get; set; }
+
+        /// <summary> Configuration of asynchronous Downtime retries (Optional) </summary>
+        public Downtime Downtime { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request introduces new features for handling payment retries in the `CheckoutSdk` library and updates the `PaymentRequest` class to support these features. The changes include the addition of new classes for retry configurations and a modification to the `Retry` property in `PaymentRequest`.

### New Features for Payment Retry Configuration:

* [`src/CheckoutSdk/Payments/Dunning.cs`](diffhunk://#diff-6f3d824c32c61ae0ada3c675e5561c18b5b17b17f65d2bd97465402d00a40a41R1-R16): Added the `Dunning` class to configure retries for payments declined with supported decline codes. It includes properties for enabling retries, setting the maximum number of attempts (`MaxAttempts`), and specifying the duration after which retries should end (`EndAfterDays`).
* [`src/CheckoutSdk/Payments/Downtime.cs`](diffhunk://#diff-c70c6d5d977584fad838e0737029965f1213149bc0ebc430840fec6de8422feeR1-R11): Added the `Downtime` class to configure retries for payments declined due to issuer or acquirer downtime. It includes a property to enable or disable this feature (`Enabled`).

### Updates to Existing Classes:

* [`src/CheckoutSdk/Payments/RetryRequest.cs`](diffhunk://#diff-496b5deab5b38b8f59c5c9aef445f0e33da7a8cf4977ad4915a4a007f8cf501bR1-R11): Added the `RetryRequest` class to encapsulate retry configurations, including `Dunning` and `Downtime`.
* [`src/CheckoutSdk/Payments/Request/PaymentRequest.cs`](diffhunk://#diff-358a2c1104b151414c1eef780125651c10e0de88593c70b05dae3e0c72fd588cL75-R75): Updated the `Retry` property in the `PaymentRequest` class to use the new `RetryRequest` class instead of the previous `PaymentRetryRequest`.