### PR TITLE
Add new evidence types to DisputeRelevantEvidence enum

### DIFF
--- a/src/CheckoutSdk/Disputes/DisputeRelevantEvidence.cs
+++ b/src/CheckoutSdk/Disputes/DisputeRelevantEvidence.cs
@@ -21,9 +21,15 @@ namespace Checkout.Disputes
 
         [EnumMember(Value = "recurring_transaction_agreement")]
         RecurringTransactionAgreement,
+        
+        [EnumMember(Value = "proof_of_delivery_or_service_date")]
+        ProofOfDeliveryOrServiceDate,
 
         [EnumMember(Value = "additional_evidence")]
         AdditionalEvidence,
+        
+        [EnumMember(Value = "compelling_evidence")]
+        CompellingEvidence,
         
         [EnumMember(Value = "arbitration_no_review")]
         ArbitrationNoReview,


### PR DESCRIPTION
This pull request updates the `DisputeRelevantEvidence` enum in the `src/CheckoutSdk/Disputes/DisputeRelevantEvidence.cs` file by adding new evidence types. These changes enhance the enum to support additional dispute evidence scenarios.

### Enum Updates:
* Added `ProofOfDeliveryOrServiceDate` to represent evidence of delivery or service dates.
* Added `CompellingEvidence` to include strong evidence supporting a dispute case.