### PR TITLE
Add CancelAScheduledRetry endpoint and related classes

### DIFF
--- a/src/CheckoutSdk/Payments/IPaymentsClient.cs
+++ b/src/CheckoutSdk/Payments/IPaymentsClient.cs
@@ -29,6 +29,12 @@ namespace Checkout.Payments
             string paymentId,
             CancellationToken cancellationToken = default);
 
+        Task<CancelAScheduledRetryResponse> CancelAScheduledRetry(
+            string paymentId,
+            CancelAScheduledRetryRequest cancelAScheduledRetryRequest,
+            string idempotencyKey = null,
+            CancellationToken cancellationToken = default);
+
         Task<CaptureResponse> CapturePayment(
             string paymentId,
             CaptureRequest captureRequest = null,

--- a/src/CheckoutSdk/Payments/PaymentsClient.cs
+++ b/src/CheckoutSdk/Payments/PaymentsClient.cs
@@ -8,6 +8,7 @@ namespace Checkout.Payments
     public class PaymentsClient : AbstractClient, IPaymentsClient
     {
         private const string PaymentsPath = "payments";
+        private const string CancelAScheduledRetryPath = "cancellations";
 
         public PaymentsClient(
             IApiClient apiClient,
@@ -71,6 +72,19 @@ namespace Checkout.Payments
             return ApiClient.Get<ItemsResponse<PaymentAction>>(BuildPath(PaymentsPath, paymentId, "actions"),
                 SdkAuthorization(),
                 cancellationToken);
+        }
+        
+        public Task<CancelAScheduledRetryResponse> CancelAScheduledRetry(string paymentId, CancelAScheduledRetryRequest cancelAScheduledRetryRequest,
+            string idempotencyKey = null,
+            CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("paymentId",paymentId,"cancelAScheduledRetryRequest", cancelAScheduledRetryRequest);
+            return ApiClient.Post<CancelAScheduledRetryResponse>(
+                BuildPath(PaymentsPath, paymentId, CancelAScheduledRetryPath),
+                SdkAuthorization(),
+                cancelAScheduledRetryRequest,
+                cancellationToken,
+                idempotencyKey);
         }
 
         public Task<CaptureResponse> CapturePayment(

--- a/src/CheckoutSdk/Payments/Request/CancelAScheduledRetryRequest.cs
+++ b/src/CheckoutSdk/Payments/Request/CancelAScheduledRetryRequest.cs
@@ -1,0 +1,7 @@
+namespace Checkout.Payments.Request
+{
+    public class CancelAScheduledRetryRequest
+    {
+        public string Reference { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Payments/Response/CancelAScheduledRetryResponse.cs
+++ b/src/CheckoutSdk/Payments/Response/CancelAScheduledRetryResponse.cs
@@ -1,0 +1,11 @@
+using Checkout.Common;
+
+namespace Checkout.Payments.Response
+{
+    public class CancelAScheduledRetryResponse : Resource
+    {
+        public string ActionId { get; set; }
+        
+        public string Reference { get; set; }
+    }
+}

--- a/test/CheckoutSdkTest/Payments/PaymentsClientTest.cs
+++ b/test/CheckoutSdkTest/Payments/PaymentsClientTest.cs
@@ -17,6 +17,7 @@ namespace Checkout.Payments
     public class PaymentsClientTest : UnitTestFixture
     {
         private const string PaymentsPath = "payments";
+        private const string CancelAScheduledRetryPath = "cancellations";
 
         private readonly SdkAuthorization _authorization = new SdkAuthorization(PlatformType.Default, ValidDefaultSk);
         private readonly Mock<IApiClient> _apiClient = new Mock<IApiClient>();
@@ -260,6 +261,29 @@ namespace Checkout.Payments
             response.ShouldNotBeNull();
             response.ShouldBeSameAs(paymentActions);
         }
+        
+        [Fact]
+        private async Task ShouldCancelAScheduledRetry()
+        {
+            var cancelAScheduledRetryRequest = new CancelAScheduledRetryRequest();
+            var cancelAScheduledRetryResponse = new CancelAScheduledRetryResponse();
+
+            _apiClient.Setup(apiClient =>
+                    apiClient.Post<CancelAScheduledRetryResponse>(
+                        PaymentsPath + "/payment_id/" + CancelAScheduledRetryPath,
+                        _authorization,
+                        cancelAScheduledRetryRequest,
+                        CancellationToken.None,
+                        "test"))
+                .ReturnsAsync(() => cancelAScheduledRetryResponse);
+
+            IPaymentsClient paymentsClient = new PaymentsClient(_apiClient.Object, _configuration.Object);
+
+            var response = await paymentsClient.CancelAScheduledRetry("payment_id", cancelAScheduledRetryRequest, "test");
+
+            response.ShouldNotBeNull();
+            response.ShouldBeSameAs(cancelAScheduledRetryResponse);
+        }
 
         [Fact]
         private async Task ShouldCapturePayment_Id()
@@ -304,7 +328,8 @@ namespace Checkout.Payments
             var captureResponse = new CaptureResponse();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Post<CaptureResponse>(PaymentsPath + "/payment_id/captures", _authorization,
+                    apiClient.Post<CaptureResponse>(PaymentsPath + "/payment_id/captures", 
+                        _authorization,
                         captureRequest,
                         CancellationToken.None, "test"))
                 .ReturnsAsync(() => captureResponse);

--- a/test/CheckoutSdkTest/Payments/RequestPaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/RequestPaymentsIntegrationTest.cs
@@ -249,6 +249,23 @@ namespace Checkout.Payments
             paymentResponse.HasLink("void").ShouldBeTrue();
         }
 
+        [Fact(Skip = "Use on demand")]
+        private async Task ShouldCancelAScheduleRetry()
+        {
+            var paymentResponse = await MakeCardPayment();
+            
+            var request = new CancelAScheduledRetryRequest
+            {
+                Reference = paymentResponse.Reference,
+            };
+
+            var response = await DefaultApi.PaymentsClient().CancelAScheduledRetry(paymentResponse.Id, request);
+
+            response.ShouldNotBeNull();
+            response.ActionId.ShouldNotBeNullOrEmpty();
+            response.Reference.ShouldNotBeNullOrEmpty();
+        }
+
         [Fact]
         private async Task ShouldTokenPayment()
         {


### PR DESCRIPTION
This pull request introduces a new feature to handle the cancellation of scheduled retries for payments in the `CheckoutSdk`. The changes include adding a new API method, creating corresponding request and response models, and implementing unit and integration tests for this functionality.

### New Feature: Cancel a Scheduled Retry

#### API Implementation:
* Added a new method, `CancelAScheduledRetry`, to the `IPaymentsClient` interface and its implementation in `PaymentsClient`. This method validates parameters and sends a POST request to the `cancellations` endpoint to cancel a scheduled retry. (`src/CheckoutSdk/Payments/IPaymentsClient.cs` - [[1]](diffhunk://#diff-9989f3896435934d0d72f7b930145764c96311c895ae9c3f2e0f540d9a05a502R32-R37) `src/CheckoutSdk/Payments/PaymentsClient.cs` - [[2]](diffhunk://#diff-4268ee75d24bfad7856e52ec5739825f2b4d8a58919216607dfca67b4babecb0R77-R89)
* Introduced a constant `CancelAScheduledRetryPath` in `PaymentsClient` to define the new endpoint path. (`src/CheckoutSdk/Payments/PaymentsClient.cs` - [src/CheckoutSdk/Payments/PaymentsClient.csR11](diffhunk://#diff-4268ee75d24bfad7856e52ec5739825f2b4d8a58919216607dfca67b4babecb0R11))

#### Request and Response Models:
* Created a new `CancelAScheduledRetryRequest` class to encapsulate the request payload, including a `Reference` property. (`src/CheckoutSdk/Payments/Request/CancelAScheduledRetryRequest.cs` - [src/CheckoutSdk/Payments/Request/CancelAScheduledRetryRequest.csR1-R7](diffhunk://#diff-0a41d2712d1bf98055ccfdc28be794943118ecb8fd7c892e814fa768b747a61dR1-R7))
* Created a new `CancelAScheduledRetryResponse` class to handle the API response, including properties for `ActionId` and `Reference`. (`src/CheckoutSdk/Payments/Response/CancelAScheduledRetryResponse.cs` - [src/CheckoutSdk/Payments/Response/CancelAScheduledRetryResponse.csR1-R11](diffhunk://#diff-47f4dcd19bd2045f37d096705be4f0fa7b149f13642e2e595ff0efb9867c5ceaR1-R11))

#### Testing:
* Added a unit test, `ShouldCancelAScheduledRetry`, to validate the behavior of the `CancelAScheduledRetry` method in `PaymentsClientTest`. (`test/CheckoutSdkTest/Payments/PaymentsClientTest.cs` - [test/CheckoutSdkTest/Payments/PaymentsClientTest.csR265-R287](diffhunk://#diff-567539b631b1380b17f6df28007642ad5a67a6505205e2e0c25e18b10726cd90R265-R287))
* Added an integration test, `ShouldCancelAScheduleRetry`, to verify the end-to-end functionality of the new feature. This test is marked with `[Fact(Skip = "Use on demand")]` for conditional execution. (`test/CheckoutSdkTest/Payments/RequestPaymentsIntegrationTest.cs` - [test/CheckoutSdkTest/Payments/RequestPaymentsIntegrationTest.csR252-R268](diffhunk://#diff-c7e8bc5db512b65bb1ca3ab45dc281f2c9217a89f0305cb01904eaa0e2140d4aR252-R268))