### PR TITLE
Add signature handling for dLocal API requests

### DIFF
--- a/src/CheckoutSdk/Forward/Requests/DestinationRequest.cs
+++ b/src/CheckoutSdk/Forward/Requests/DestinationRequest.cs
@@ -1,3 +1,5 @@
+using Checkout.Forward.Requests.Signatures;
+
 namespace Checkout.Forward.Requests
 {
     public class DestinationRequest
@@ -17,5 +19,10 @@ namespace Checkout.Forward.Requests
         ///     payment instrument you specified. For example, {{card_number}} (Required, max 16384 characters)
         /// </summary>
         public string Body { get; set; }
+        
+        /// <summary>
+        ///     Optional configuration to add a signature to the forwarded HTTP request (Optional).
+        /// </summary>
+        public AbstractSignature Signature { get; set; }
     }
 }

--- a/src/CheckoutSdk/Forward/Requests/Signatures/AbstractSignature.cs
+++ b/src/CheckoutSdk/Forward/Requests/Signatures/AbstractSignature.cs
@@ -1,0 +1,13 @@
+namespace Checkout.Forward.Requests.Signatures
+{
+    public abstract class AbstractSignature
+    {
+        protected AbstractSignature(SignatureType type) { Type = type; }
+
+        /// <summary>
+        ///     The identifier of the supported signature generation method or a specific third-party service.
+        ///     (Required)
+        /// </summary>
+        public SignatureType? Type { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Forward/Requests/Signatures/DlocalParameters.cs
+++ b/src/CheckoutSdk/Forward/Requests/Signatures/DlocalParameters.cs
@@ -1,0 +1,10 @@
+namespace Checkout.Forward.Requests.Signatures
+{
+    public class DlocalParameters
+    {
+        /// <summary>
+        ///     The secret key used to generate the request signature. This is part of the dLocal API credentials.
+        /// </summary>
+        public string SecretKey { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Forward/Requests/Signatures/DlocalSignature.cs
+++ b/src/CheckoutSdk/Forward/Requests/Signatures/DlocalSignature.cs
@@ -1,0 +1,14 @@
+namespace Checkout.Forward.Requests.Signatures
+{
+    public class DlocalSignature
+    {
+        /// <summary>
+        ///     The parameters required to generate an HMAC signature for the dLocal API. See their documentation for
+        ///     details.
+        ///     This method requires you to provide the X-Login header value in the destination request headers.
+        ///     When used, the Forward API appends the X-Date and Authorization headers to the outgoing HTTP request
+        ///     before forwarding.
+        /// </summary>
+        public DlocalParameters DlocalParameters { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Forward/Requests/Signatures/SignatureType.cs
+++ b/src/CheckoutSdk/Forward/Requests/Signatures/SignatureType.cs
@@ -1,0 +1,10 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Forward.Requests.Signatures
+{
+    public enum SignatureType
+    {
+        [EnumMember(Value = "dlocal")]
+        Dlocal,
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for supporting request signatures in the `Forward` module of the Checkout SDK. It adds the ability to configure and generate signatures, specifically for the dLocal API, by extending the `DestinationRequest` class and introducing new classes and enums for signature handling.

### Enhancements to request signature support:

* **`DestinationRequest` class update**: Added an optional `Signature` property of type `AbstractSignature` to allow configuration of request signatures. (`src/CheckoutSdk/Forward/Requests/DestinationRequest.cs`, [src/CheckoutSdk/Forward/Requests/DestinationRequest.csR22-R26](diffhunk://#diff-0abdb51bbff36fa20695b6921db64cb9cd687e98d5e8926dfbdeb212a5310cc1R22-R26))
* **`AbstractSignature` class**: Introduced an abstract class to define the base structure for signature generation, including a `Type` property for specifying the signature type. (`src/CheckoutSdk/Forward/Requests/Signatures/AbstractSignature.cs`, [src/CheckoutSdk/Forward/Requests/Signatures/AbstractSignature.csR1-R13](diffhunk://#diff-05102cf9a3eb5a0bbfe44c90e2fb886a6fffffe2e726534473a03eb1bc820992R1-R13))

### dLocal-specific signature implementation:

* **`DlocalParameters` class**: Added a class to encapsulate the required parameters, such as the `SecretKey`, for generating dLocal API signatures. (`src/CheckoutSdk/Forward/Requests/Signatures/DlocalParameters.cs`, [src/CheckoutSdk/Forward/Requests/Signatures/DlocalParameters.csR1-R10](diffhunk://#diff-a06743d4b4b49b9d54efb6017c748a73b6df8e953c165cfc03d252e4ed6eb4cfR1-R10))
* **`DlocalSignature` class**: Created a class to handle dLocal-specific signature generation, including appending headers like `X-Date` and `Authorization` to outgoing requests. (`src/CheckoutSdk/Forward/Requests/Signatures/DlocalSignature.cs`, [src/CheckoutSdk/Forward/Requests/Signatures/DlocalSignature.csR1-R14](diffhunk://#diff-91243488158aa1e240657b1361ad873d1ada3365c39b1c2ddf68171642ce582cR1-R14))
* **`SignatureType` enum**: Added an enum to define supported signature types, starting with `Dlocal`. (`src/CheckoutSdk/Forward/Requests/Signatures/SignatureType.cs`, [src/CheckoutSdk/Forward/Requests/Signatures/SignatureType.csR1-R10](diffhunk://#diff-3a5627fdaafbc61a3627f8608369675cd584bf72dcef87a1ef7abe2e4aa27bffR1-R10))