### PR TITLE
Add constructor to DlocalSignature and integrate it into Tests

### DIFF
--- a/src/CheckoutSdk/Forward/Requests/DestinationRequest.cs
+++ b/src/CheckoutSdk/Forward/Requests/DestinationRequest.cs
@@ -21,7 +21,7 @@ namespace Checkout.Forward.Requests
         public string Body { get; set; }
         
         /// <summary>
-        ///     Optional configuration to add a signature to the forwarded HTTP request (Optional).
+        ///     Optional configuration to add a signature to the forwarded HTTP request. (Optional)
         /// </summary>
         public AbstractSignature Signature { get; set; }
     }

--- a/src/CheckoutSdk/Forward/Requests/Signatures/DlocalSignature.cs
+++ b/src/CheckoutSdk/Forward/Requests/Signatures/DlocalSignature.cs
@@ -1,7 +1,10 @@
 namespace Checkout.Forward.Requests.Signatures
 {
-    public class DlocalSignature
+    public class DlocalSignature : AbstractSignature
     {
+        /// <summary> Initializes a new instance of the DlocalSignature class. </summary>
+        public DlocalSignature() : base(SignatureType.Dlocal) { }
+        
         /// <summary>
         ///     The parameters required to generate an HMAC signature for the dLocal API. See their documentation for
         ///     details.

--- a/test/CheckoutSdkTest/Forward/ForwardIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Forward/ForwardIntegrationTest.cs
@@ -1,4 +1,5 @@
 ﻿using Checkout.Forward.Requests;
+using Checkout.Forward.Requests.Signatures;
 using Checkout.Forward.Requests.Sources;
 using Shouldly;
 using System.Collections.Generic;
@@ -67,7 +68,14 @@ namespace Checkout.Forward
                                 }
                         },
                     Body =
-                        "{\"amount\": 1000, \"currency\": \"USD\", \"reference\": \"some_reference\", \"source\": {\"type\": \"card\", \"number\": \"{{card_number}}\", \"expiry_month\": \"{{card_expiry_month}}\", \"expiry_year\": \"{{card_expiry_year_yyyy}}\", \"name\": \"Ali Farid\"}, \"payment_type\": \"Regular\", \"authorization_type\": \"Final\", \"capture\": true, \"processing_channel_id\": \"pc_xxxxxxxxxxx\", \"risk\": {\"enabled\": false}, \"merchant_initiated\": true}"
+                        "{\"amount\": 1000, \"currency\": \"USD\", \"reference\": \"some_reference\", \"source\": {\"type\": \"card\", \"number\": \"{{card_number}}\", \"expiry_month\": \"{{card_expiry_month}}\", \"expiry_year\": \"{{card_expiry_year_yyyy}}\", \"name\": \"Ali Farid\"}, \"payment_type\": \"Regular\", \"authorization_type\": \"Final\", \"capture\": true, \"processing_channel_id\": \"pc_xxxxxxxxxxx\", \"risk\": {\"enabled\": false}, \"merchant_initiated\": true}",
+                    Signature = new DlocalSignature
+                    {
+                        DlocalParameters = new DlocalParameters
+                        {
+                            SecretKey = "9f439fe1a9f96e67b047d3c1a28c33a2e"
+                        }
+                    }
                 }
             };
         }


### PR DESCRIPTION
This pull request introduces functionality for handling dLocal signatures in the Checkout SDK. The most important changes include extending the `DlocalSignature` class from `AbstractSignature`, adding a constructor to initialize it with a specific signature type, and updating the integration test to include the new signature functionality.

### Enhancements to Signature Handling:

* [`src/CheckoutSdk/Forward/Requests/Signatures/DlocalSignature.cs`](diffhunk://#diff-91243488158aa1e240657b1361ad873d1ada3365c39b1c2ddf68171642ce582cL3-R7): Extended the `DlocalSignature` class from `AbstractSignature` and added a constructor to initialize it with `SignatureType.Dlocal`. This change establishes the class as part of the signature hierarchy and enables it to handle dLocal-specific parameters.

### Updates to Integration Tests:

* [`test/CheckoutSdkTest/Forward/ForwardIntegrationTest.cs`](diffhunk://#diff-fae4bab850ab3d49c496e12058b85a9da6d066d54b576512c649b485050c6e64R2): Added the `Checkout.Forward.Requests.Signatures` namespace to include the new `DlocalSignature` class.
* [`test/CheckoutSdkTest/Forward/ForwardIntegrationTest.cs`](diffhunk://#diff-fae4bab850ab3d49c496e12058b85a9da6d066d54b576512c649b485050c6e64L70-R78): Updated the `CreateForwardRequest` method to include a `Signature` property using the new `DlocalSignature` class. This ensures the integration test covers the new functionality for dLocal signatures.