### PR TITLE
Add SubType constants and update Product struct in payments

### DIFF
--- a/src/CheckoutSdk/Payments/ProcessingSettings.cs
+++ b/src/CheckoutSdk/Payments/ProcessingSettings.cs
@@ -79,5 +79,12 @@ namespace Checkout.Payments
         
         [JsonProperty(PropertyName = "senderInformation")]
         public string SenderInformation { get; set; }
+        
+        public CardType? CardType { get; set; }
+        
+        public string AffiliateId { get; set; }
+        
+        public string AffiliateUrl { get; set; }
+        
     }
 }

--- a/src/CheckoutSdk/Payments/Request/ItemSubType.cs
+++ b/src/CheckoutSdk/Payments/Request/ItemSubType.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Payments.Request
+{
+    public enum ItemSubType
+    {
+        [EnumMember(Value = "blockchain")]
+        Blockchain,
+            
+        [EnumMember(Value = "cbdc")]
+        Cbdc,
+        
+        [EnumMember(Value = "cryptocurrency")]
+        Cryptocurrency,
+        
+        [EnumMember(Value = "nft")]
+        Nft,
+        
+        [EnumMember(Value = "stablecoin")]
+        Stablecoin,
+            
+    }
+}

--- a/src/CheckoutSdk/Payments/Request/ItemType.cs
+++ b/src/CheckoutSdk/Payments/Request/ItemType.cs
@@ -1,0 +1,16 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Payments.Request
+{
+    public enum ItemType
+    {
+        [EnumMember(Value = "digital")]
+        Digital,
+        
+        [EnumMember(Value = "discount")]
+        Discount,
+        
+        [EnumMember(Value = "physical")]
+        Physical,
+    }
+}

--- a/src/CheckoutSdk/Payments/Request/Product.cs
+++ b/src/CheckoutSdk/Payments/Request/Product.cs
@@ -2,6 +2,9 @@
 {
     public class Product
     {
+        public ItemType Type { get; set; }
+        
+        public ItemSubType SubType { get; set; }
         public string Name { get; set; }
 
         public long? Quantity { get; set; }


### PR DESCRIPTION
This pull request introduces enhancements to the payments processing and product modeling features. The main changes add support for specifying product types and subtypes, as well as extending processing settings with new card and affiliate-related properties.

**Product modeling improvements:**

- Added `ItemType` and `ItemSubType` enums to represent the type and subtype of products, such as digital, physical, blockchain, cryptocurrency, etc. (`ItemType.cs` [[1]](diffhunk://#diff-4083353c73e6a1be091eb97da6379a9c23f267d44f5438c28baad2da3f5dd83dR1-R16) `ItemSubType.cs` [[2]](diffhunk://#diff-ae48da4dd588cde16a88d45a1c4a9349f917bcf7ee71ba95001bd23a1763d9aaR1-R23)
- Updated the `Product` class to include `Type` and `SubType` properties, enabling more granular product categorization. (`Product.cs` [src/CheckoutSdk/Payments/Request/Product.csR5-R7](diffhunk://#diff-a5a5edd772980d4a9dfdac7ed1bea6d57932348116f71eed0c5ca6d12732c499R5-R7))

**Processing settings enhancements:**

- Extended the `ProcessingSettings` class to include optional `CardType`, `AffiliateId`, and `AffiliateUrl` properties, allowing for more detailed payment processing configurations. (`ProcessingSettings.cs` [src/CheckoutSdk/Payments/ProcessingSettings.csR82-R88](diffhunk://#diff-1b05c3bd56e2a2048753b2bbdb93b416c205463fead40a006f082b8c7e1f50c7R82-R88))