### PR TITLE
feat: add PaymentRouting, PaymentSubscription and missing fields to PaymentRequest

### DIFF
--- a/src/CheckoutSdk/Payments/Request/PaymentRequest.cs
+++ b/src/CheckoutSdk/Payments/Request/PaymentRequest.cs
@@ -9,73 +9,251 @@ namespace Checkout.Payments.Request
 {
     public class PaymentRequest
     {
+        /// <summary>
+        /// Payment Context's unique identifier.
+        /// [Optional]
+        /// </summary>
         public string PaymentContextId { get; set; }
-        
+
+        /// <summary>
+        /// The source of the payment.
+        /// [Required]
+        /// </summary>
         public AbstractRequestSource Source { get; set; }
 
+        /// <summary>
+        /// The payment amount. To perform a card verification, do not provide the amount or provide a value of 0.
+        /// The amount must be provided in the minor currency unit.
+        /// [Optional]
+        /// >= 0
+        /// &lt;= 9999999999
+        /// </summary>
         public long? Amount { get; set; }
 
+        /// <summary>
+        /// The three-letter ISO currency code.
+        /// [Optional]
+        /// >= 3 characters
+        /// &lt;= 3 characters
+        /// </summary>
         public Currency? Currency { get; set; }
 
+        /// <summary>
+        /// The type of payment. Required for card payments where the cardholder is not present (MOTO, MIT, recurring).
+        /// For MITs, must not be set to Regular.
+        /// [Optional]
+        /// Enum: "Regular" "Recurring" "MOTO" "Installment" "PayLater" "Unscheduled"
+        /// </summary>
         public PaymentType? PaymentType { get; set; } = Payments.PaymentType.Regular;
-        
+
+        /// <summary>
+        /// The details of a recurring subscription or installment.
+        /// [Optional]
+        /// </summary>
         public PaymentPlan PaymentPlan { get; set; }
 
+        /// <summary>
+        /// Whether the payment is a merchant-initiated transaction (MIT).
+        /// Must be set to true for all MITs. If true, payment_type must not be Regular.
+        /// [Optional]
+        /// </summary>
         public bool? MerchantInitiated { get; set; }
 
+        /// <summary>
+        /// A reference you can use to identify the payment (e.g. an order number).
+        /// [Optional]
+        /// &lt;= 80 characters
+        /// </summary>
         public string Reference { get; set; }
 
+        /// <summary>
+        /// A description of the payment.
+        /// [Optional]
+        /// &lt;= 100 characters
+        /// </summary>
         public string Description { get; set; }
-        
-        public Authentication Authentication { get; set; }
 
+        /// <summary>
+        /// The authorization type.
+        /// [Optional]
+        /// Enum: "Final" "Estimated"
+        /// </summary>
         public AuthorizationType? AuthorizationType { get; set; }
 
+        /// <summary>
+        /// Partial authorization configuration for the payment.
+        /// [Optional]
+        /// </summary>
         public PartialAuthorization PartialAuthorization { get; set; }
 
+        /// <summary>
+        /// Whether to capture the payment (if applicable).
+        /// [Optional]
+        /// </summary>
         public bool? Capture { get; set; }
 
+        /// <summary>
+        /// A timestamp (ISO 8601) that determines when the payment should be captured.
+        /// Providing this field will automatically set capture to true.
+        /// [Optional]
+        /// Format: date-time (RFC 3339)
+        /// </summary>
         public DateTime? CaptureOn { get; set; }
 
+        /// <summary>
+        /// The date and time when the payment expires in UTC (e.g. Multibanco payments).
+        /// [Optional]
+        /// Format: date-time (RFC 3339)
+        /// </summary>
+        public DateTime? ExpireOn { get; set; }
+
+        /// <summary>
+        /// Customer information for the payment.
+        /// [Optional]
+        /// </summary>
         public CustomerRequest Customer { get; set; }
 
+        /// <summary>
+        /// Dynamic billing descriptor displayed on the customer's bank statement.
+        /// [Optional]
+        /// </summary>
         public BillingDescriptor BillingDescriptor { get; set; }
 
+        /// <summary>
+        /// Shipping details for the payment.
+        /// [Optional]
+        /// </summary>
         public ShippingDetails Shipping { get; set; }
-        
-        public PaymentSegment Segment { get; set; }
 
-        [JsonProperty(PropertyName = "3ds")] public ThreeDsRequest ThreeDs { get; set; }
+        /// <summary>
+        /// Provides information required to authenticate payments.
+        /// [Optional]
+        /// </summary>
+        public Authentication Authentication { get; set; }
 
+        /// <summary>
+        /// Information required for 3D Secure authentication payments.
+        /// [Optional]
+        /// </summary>
+        [JsonProperty(PropertyName = "3ds")]
+        public ThreeDsRequest ThreeDs { get; set; }
+
+        /// <summary>
+        /// The processing channel to be used for the payment.
+        /// [Optional]
+        /// ^(pc)_(\w{26})$
+        /// </summary>
         public string ProcessingChannelId { get; set; }
 
+        /// <summary>
+        /// An identifier linking the payment to an existing recurring series.
+        /// Only pass for MIT transactions in a recurring series.
+        /// [Optional]
+        /// &lt;= 100 characters
+        /// </summary>
         public string PreviousPaymentId { get; set; }
 
+        /// <summary>
+        /// Risk assessment configuration for the payment.
+        /// [Optional]
+        /// </summary>
         public RiskRequest Risk { get; set; }
 
+        /// <summary>
+        /// For redirect payment methods, overrides the default success redirect URL configured on your account.
+        /// [Optional]
+        /// Format: uri
+        /// &lt;= 1024 characters
+        /// </summary>
         public string SuccessUrl { get; set; }
 
+        /// <summary>
+        /// For redirect payment methods, overrides the default failure redirect URL configured on your account.
+        /// [Optional]
+        /// Format: uri
+        /// &lt;= 1024 characters
+        /// </summary>
         public string FailureUrl { get; set; }
 
+        /// <summary>
+        /// The IP address used to make the payment. Only accepts IPv4 and IPv6 addresses.
+        /// [Optional]
+        /// </summary>
+        [Obsolete("Use risk.device.network.ipv4 or risk.device.network.ipv6 instead.", false)]
         public string PaymentIp { get; set; }
 
+        /// <summary>
+        /// The sender of the payment.
+        /// [Optional]
+        /// </summary>
         public PaymentSender Sender { get; set; }
 
+        /// <summary>
+        /// The recipient of the payment.
+        /// [Optional]
+        /// </summary>
         public PaymentRecipient Recipient { get; set; }
 
+        /// <summary>
+        /// Marketplace data for the payment.
+        /// [Optional]
+        /// </summary>
         [Obsolete("This property will be removed in the future, and should not be used. Use AmountAllocations instead.", false)]
         public MarketplaceData Marketplace { get; set; }
-        
+
+        /// <summary>
+        /// The amount allocations for marketplace payments.
+        /// [Optional]
+        /// </summary>
         public IList<AmountAllocations> AmountAllocations { get; set; }
 
+        /// <summary>
+        /// Additional payment processing settings.
+        /// [Optional]
+        /// </summary>
         public ProcessingSettings Processing { get; set; }
 
+        /// <summary>
+        /// The line items in the order associated with the payment.
+        /// [Optional]
+        /// </summary>
         public IList<Product> Items { get; set; }
 
+        /// <summary>
+        /// Retry configuration for the payment (Dunning and Downtime).
+        /// [Optional]
+        /// </summary>
         public RetryRequest Retry { get; set; }
 
+        /// <summary>
+        /// The details of the subscription linking this payment to a recurring series.
+        /// [Optional]
+        /// </summary>
+        public PaymentSubscription Subscription { get; set; }
+
+        /// <summary>
+        /// Controls processor attempts at the payment level.
+        /// [Optional]
+        /// </summary>
+        public PaymentRouting Routing { get; set; }
+
+        /// <summary>
+        /// Stores additional information about the transaction. Supports string, number, and boolean fields.
+        /// Up to 20 fields per call; each value must not exceed 255 characters.
+        /// [Optional]
+        /// </summary>
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
-        
+
+        /// <summary>
+        /// The segment associated with the payment.
+        /// [Optional]
+        /// </summary>
+        public PaymentSegment Segment { get; set; }
+
+        /// <summary>
+        /// Details about the payment instruction.
+        /// [Optional]
+        /// </summary>
         public PaymentInstruction Instruction { get; set; }
     }
 }

--- a/src/CheckoutSdk/Payments/Request/PaymentRouting.cs
+++ b/src/CheckoutSdk/Payments/Request/PaymentRouting.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Checkout.Payments.Request
+{
+    public class PaymentRouting
+    {
+        /// <summary>
+        /// Specifies the processing rules for the payment. Each object in the array
+        /// should be a unique expression of rules that determine the routing attempts
+        /// to process the payment with.
+        /// [Optional]
+        /// </summary>
+        public IList<PaymentRoutingAttempt> Attempts { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Payments/Request/PaymentRoutingAttempt.cs
+++ b/src/CheckoutSdk/Payments/Request/PaymentRoutingAttempt.cs
@@ -1,0 +1,13 @@
+namespace Checkout.Payments.Request
+{
+    public class PaymentRoutingAttempt
+    {
+        /// <summary>
+        /// The card scheme to use for the payment attempt.
+        /// [Optional]
+        /// Enum: "accel" "amex" "cartes_bancaires" "diners" "discover" "jcb" "mada"
+        ///       "maestro" "mastercard" "nyce" "omannet" "pulse" "shazam" "star" "upi" "visa"
+        /// </summary>
+        public PaymentRoutingScheme? Scheme { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Payments/Request/PaymentRoutingScheme.cs
+++ b/src/CheckoutSdk/Payments/Request/PaymentRoutingScheme.cs
@@ -1,0 +1,71 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Payments.Request
+{
+    public enum PaymentRoutingScheme
+    {
+        /// <summary>Accel PINless debit network (US).</summary>
+        [EnumMember(Value = "accel")]
+        Accel,
+
+        /// <summary>American Express.</summary>
+        [EnumMember(Value = "amex")]
+        Amex,
+
+        /// <summary>Cartes Bancaires local scheme (France).</summary>
+        [EnumMember(Value = "cartes_bancaires")]
+        CartesBancaires,
+
+        /// <summary>Diners Club International.</summary>
+        [EnumMember(Value = "diners")]
+        Diners,
+
+        /// <summary>Discover Network.</summary>
+        [EnumMember(Value = "discover")]
+        Discover,
+
+        /// <summary>JCB (Japan Credit Bureau).</summary>
+        [EnumMember(Value = "jcb")]
+        Jcb,
+
+        /// <summary>mada local scheme (Saudi Arabia).</summary>
+        [EnumMember(Value = "mada")]
+        Mada,
+
+        /// <summary>Maestro local scheme.</summary>
+        [EnumMember(Value = "maestro")]
+        Maestro,
+
+        /// <summary>Mastercard.</summary>
+        [EnumMember(Value = "mastercard")]
+        Mastercard,
+
+        /// <summary>NYCE PINless debit network (US).</summary>
+        [EnumMember(Value = "nyce")]
+        Nyce,
+
+        /// <summary>OmanNet local scheme (Oman).</summary>
+        [EnumMember(Value = "omannet")]
+        Omannet,
+
+        /// <summary>Pulse PINless debit network (US).</summary>
+        [EnumMember(Value = "pulse")]
+        Pulse,
+
+        /// <summary>Shazam PINless debit network (US).</summary>
+        [EnumMember(Value = "shazam")]
+        Shazam,
+
+        /// <summary>Star PINless debit network (US).</summary>
+        [EnumMember(Value = "star")]
+        Star,
+
+        /// <summary>UnionPay International (China).</summary>
+        [EnumMember(Value = "upi")]
+        Upi,
+
+        /// <summary>Visa.</summary>
+        [EnumMember(Value = "visa")]
+        Visa,
+    }
+}

--- a/src/CheckoutSdk/Payments/Request/PaymentSubscription.cs
+++ b/src/CheckoutSdk/Payments/Request/PaymentSubscription.cs
@@ -1,0 +1,12 @@
+namespace Checkout.Payments.Request
+{
+    public class PaymentSubscription
+    {
+        /// <summary>
+        /// The ID or reference linking a series of recurring payments together.
+        /// [Optional]
+        /// &lt;= 50 characters
+        /// </summary>
+        public string Id { get; set; }
+    }
+}

--- a/test/CheckoutSdkTest/Payments/PaymentRoutingSerializationTest.cs
+++ b/test/CheckoutSdkTest/Payments/PaymentRoutingSerializationTest.cs
@@ -1,0 +1,122 @@
+using Checkout.Payments.Request;
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Checkout.Payments
+{
+    public class PaymentRoutingSerializationTest
+    {
+        private static readonly JsonSerializer Serializer = new JsonSerializer();
+
+        [Fact]
+        public void ShouldSerializePaymentRoutingWithAllSchemes()
+        {
+            var routing = new PaymentRouting
+            {
+                Attempts = new List<PaymentRoutingAttempt>
+                {
+                    new PaymentRoutingAttempt { Scheme = PaymentRoutingScheme.Mastercard },
+                    new PaymentRoutingAttempt { Scheme = PaymentRoutingScheme.Visa }
+                }
+            };
+
+            var json = Serializer.Serialize(routing);
+
+            json.ShouldContain("\"mastercard\"");
+            json.ShouldContain("\"visa\"");
+        }
+
+        [Fact]
+        public void ShouldRoundTripSerializePaymentRouting()
+        {
+            var original = new PaymentRouting
+            {
+                Attempts = new List<PaymentRoutingAttempt>
+                {
+                    new PaymentRoutingAttempt { Scheme = PaymentRoutingScheme.Mastercard },
+                    new PaymentRoutingAttempt { Scheme = PaymentRoutingScheme.Visa }
+                }
+            };
+
+            var json = Serializer.Serialize(original);
+            var result = (PaymentRouting)Serializer.Deserialize(json, typeof(PaymentRouting));
+
+            result.ShouldNotBeNull();
+            result.Attempts.Count.ShouldBe(2);
+            result.Attempts[0].Scheme.ShouldBe(PaymentRoutingScheme.Mastercard);
+            result.Attempts[1].Scheme.ShouldBe(PaymentRoutingScheme.Visa);
+        }
+
+        [Fact]
+        public void ShouldDeserializeAllSchemeValues()
+        {
+            const string json = @"{
+                ""attempts"": [
+                    { ""scheme"": ""accel"" },
+                    { ""scheme"": ""amex"" },
+                    { ""scheme"": ""cartes_bancaires"" },
+                    { ""scheme"": ""diners"" },
+                    { ""scheme"": ""discover"" },
+                    { ""scheme"": ""jcb"" },
+                    { ""scheme"": ""mada"" },
+                    { ""scheme"": ""maestro"" },
+                    { ""scheme"": ""mastercard"" },
+                    { ""scheme"": ""nyce"" },
+                    { ""scheme"": ""omannet"" },
+                    { ""scheme"": ""pulse"" },
+                    { ""scheme"": ""shazam"" },
+                    { ""scheme"": ""star"" },
+                    { ""scheme"": ""upi"" },
+                    { ""scheme"": ""visa"" }
+                ]
+            }";
+
+            var result = (PaymentRouting)Serializer.Deserialize(json, typeof(PaymentRouting));
+
+            result.ShouldNotBeNull();
+            result.Attempts.Count.ShouldBe(16);
+            result.Attempts[0].Scheme.ShouldBe(PaymentRoutingScheme.Accel);
+            result.Attempts[1].Scheme.ShouldBe(PaymentRoutingScheme.Amex);
+            result.Attempts[2].Scheme.ShouldBe(PaymentRoutingScheme.CartesBancaires);
+            result.Attempts[3].Scheme.ShouldBe(PaymentRoutingScheme.Diners);
+            result.Attempts[4].Scheme.ShouldBe(PaymentRoutingScheme.Discover);
+            result.Attempts[5].Scheme.ShouldBe(PaymentRoutingScheme.Jcb);
+            result.Attempts[6].Scheme.ShouldBe(PaymentRoutingScheme.Mada);
+            result.Attempts[7].Scheme.ShouldBe(PaymentRoutingScheme.Maestro);
+            result.Attempts[8].Scheme.ShouldBe(PaymentRoutingScheme.Mastercard);
+            result.Attempts[9].Scheme.ShouldBe(PaymentRoutingScheme.Nyce);
+            result.Attempts[10].Scheme.ShouldBe(PaymentRoutingScheme.Omannet);
+            result.Attempts[11].Scheme.ShouldBe(PaymentRoutingScheme.Pulse);
+            result.Attempts[12].Scheme.ShouldBe(PaymentRoutingScheme.Shazam);
+            result.Attempts[13].Scheme.ShouldBe(PaymentRoutingScheme.Star);
+            result.Attempts[14].Scheme.ShouldBe(PaymentRoutingScheme.Upi);
+            result.Attempts[15].Scheme.ShouldBe(PaymentRoutingScheme.Visa);
+        }
+
+        [Fact]
+        public void ShouldSerializeRoutingInsidePaymentRequest()
+        {
+            var request = new PaymentRequest
+            {
+                Amount = 1000,
+                Currency = Common.Currency.GBP,
+                Routing = new PaymentRouting
+                {
+                    Attempts = new List<PaymentRoutingAttempt>
+                    {
+                        new PaymentRoutingAttempt { Scheme = PaymentRoutingScheme.Mastercard },
+                        new PaymentRoutingAttempt { Scheme = PaymentRoutingScheme.Visa }
+                    }
+                }
+            };
+
+            var json = Serializer.Serialize(request);
+
+            json.ShouldContain("\"routing\"");
+            json.ShouldContain("\"attempts\"");
+            json.ShouldContain("\"mastercard\"");
+            json.ShouldContain("\"visa\"");
+        }
+    }
+}


### PR DESCRIPTION
- Add PaymentRoutingScheme enum (16 values: accel, amex, cartes_bancaires, diners, discover, jcb, mada, maestro, mastercard, nyce, omannet, pulse, shazam, star, upi, visa) aligned with swagger Attempt.scheme
- Add PaymentRoutingAttempt and PaymentRouting classes
- Add PaymentSubscription class (id field, <= 50 chars)
- Add missing ExpireOn (DateTime?) and Subscription fields to PaymentRequest
- Add XML doc comments to all properties in PaymentRequest
- Add PaymentRoutingSerializationTest covering all 16 scheme values, roundtrip and PaymentRequest integration