### PR TITLE
fix: correct AccountHolder type and add missing fields to RequestIdSource and RequestCardSource

### DIFF
--- a/src/CheckoutSdk/Payments/Request/Source/RequestCardSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestCardSource.cs
@@ -1,4 +1,5 @@
 ﻿using Checkout.Common;
+using Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.CardSource.AccountHolder;
 
 namespace Checkout.Payments.Request.Source
 {
@@ -8,25 +9,75 @@ namespace Checkout.Payments.Request.Source
         {
         }
 
+        /// <summary>
+        /// The card number (without separators).
+        /// [Required]
+        /// </summary>
         public string Number { get; set; }
 
+        /// <summary>
+        /// The expiry month of the card.
+        /// [Required]
+        /// >= 1, <= 12
+        /// </summary>
         public int? ExpiryMonth { get; set; }
 
+        /// <summary>
+        /// The 4-digit expiry year of the card.
+        /// [Required]
+        /// </summary>
         public int? ExpiryYear { get; set; }
 
+        /// <summary>
+        /// The name of the cardholder.
+        /// [Optional]
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// The card verification value/code. 3 digits, except for American Express (4 digits).
+        /// [Optional]
+        /// >= 3 characters, <= 4 characters
+        /// </summary>
         public string Cvv { get; set; }
 
+        /// <summary>
+        /// Whether this payment uses stored card details.
+        /// [Optional]
+        /// </summary>
         public bool? Stored { get; set; }
-        
+
+        /// <summary>
+        /// Whether to store the credentials for future use.
+        /// [Optional]
+        /// </summary>
         public bool? StoreForFutureUse { get; set; }
 
+        /// <summary>
+        /// The billing address of the cardholder.
+        /// [Optional]
+        /// </summary>
         public Address BillingAddress { get; set; }
 
+        /// <summary>
+        /// The phone number of the cardholder.
+        /// [Optional]
+        /// </summary>
         public Phone Phone { get; set; }
 
-        public AccountHolder AccountHolder { get; set; }
-        
+        /// <summary>
+        /// Whether to use the Real-Time Account Updater to update the card information.
+        /// [Optional]
+        /// </summary>
+        public bool? AllowUpdate { get; set; }
+
+        /// <summary>
+        /// Information about the account holder of the card.
+        /// Valid types: individual (first_name, last_name, middle_name, account_name_inquiry),
+        /// corporate (company_name, account_name_inquiry),
+        /// government (company_name, account_name_inquiry).
+        /// [Optional]
+        /// </summary>
+        public AbstractAccountHolder AccountHolder { get; set; }
     }
 }

--- a/src/CheckoutSdk/Payments/Request/Source/RequestIdSource.cs
+++ b/src/CheckoutSdk/Payments/Request/Source/RequestIdSource.cs
@@ -1,4 +1,5 @@
 ﻿using Checkout.Common;
+using Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.CardSource.AccountHolder;
 
 namespace Checkout.Payments.Request.Source
 {
@@ -8,17 +9,63 @@ namespace Checkout.Payments.Request.Source
         {
         }
 
+        /// <summary>
+        /// The payment source identifier.
+        /// [Required]
+        /// ^(src)_(\w{26})$
+        /// </summary>
         public string Id { get; set; }
 
+        /// <summary>
+        /// The card verification value/code.
+        /// [Optional]
+        /// ^tok_(\w{26})$|^\d{3,4}$
+        /// </summary>
         public string Cvv { get; set; }
 
+        /// <summary>
+        /// The payment method. Required for ACH payment.
+        /// [Optional]
+        /// </summary>
         public string PaymentMethod { get; set; }
 
+        /// <summary>
+        /// Whether the payment uses stored card details.
+        /// [Optional]
+        /// </summary>
         public bool? Stored { get; set; }
 
+        /// <summary>
+        /// Whether to store the credentials for future use.
+        /// [Optional]
+        /// </summary>
         public bool? StoreForFutureUse { get; set; }
-        
-        public AccountHolder AccountHolder { get; set; }
-        
+
+        /// <summary>
+        /// The cardholder's billing address.
+        /// [Optional]
+        /// </summary>
+        public Address BillingAddress { get; set; }
+
+        /// <summary>
+        /// The cardholder's phone number.
+        /// [Optional]
+        /// </summary>
+        public Phone Phone { get; set; }
+
+        /// <summary>
+        /// Whether to use the Real-Time Account Updater to update the card information.
+        /// [Optional]
+        /// </summary>
+        public bool? AllowUpdate { get; set; }
+
+        /// <summary>
+        /// Information about the account holder of the payment instrument.
+        /// Valid types: individual (first_name, last_name, middle_name, account_name_inquiry),
+        /// corporate (company_name, account_name_inquiry),
+        /// government (company_name, account_name_inquiry).
+        /// [Optional]
+        /// </summary>
+        public AbstractAccountHolder AccountHolder { get; set; }
     }
 }

--- a/test/CheckoutSdkTest/Payments/AbstractPaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/AbstractPaymentsIntegrationTest.cs
@@ -1,4 +1,5 @@
 using Checkout.Common;
+using Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.CardSource.AccountHolder.IndividualAccountHolder;
 using Checkout.Payments.Request;
 using Checkout.Payments.Request.Source;
 using Checkout.Payments.Response;
@@ -39,7 +40,7 @@ namespace Checkout.Payments
                 Cvv = TestCardSource.Visa.Cvv,
                 BillingAddress = GetAddress(),
                 Phone = GetPhone(),
-                AccountHolder = GetAccountHolder()
+                AccountHolder = new IndividualAccountHolder { FirstName = "John", LastName = "Doe" }
             };
 
             var customerRequest = new CustomerRequest {Email = GenerateRandomEmail(), Name = "Customer"};


### PR DESCRIPTION
- RequestIdSource: change AccountHolder from Checkout.Common.AccountHolder to AbstractAccountHolder; add missing top-level BillingAddress, Phone, and AllowUpdate properties to align with swagger PaymentRequestIdSource schema
- RequestCardSource: change AccountHolder from Checkout.Common.AccountHolder to AbstractAccountHolder; the legacy type exposed fields (email, full_name, billing_address) that the API's account_holder object does not accept for card sources, causing those fields to be silently stripped
- AbstractPaymentsIntegrationTest: update MakeCardPayment to use IndividualAccountHolder (first_name + last_name only) instead of the legacy AccountHolder, and promote BillingAddress/Phone to the correct top-level source fields