### PR TITLE
.Net 8.0 Migration

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        dotnet: [ '3.1', '5.0', '6.0' ]
+        dotnet: [ '3.1', '5.0', '6.0', '8.0' ]
         include:
           - dotnet: 3.1
             framework: netcoreapp3.1
@@ -19,6 +19,8 @@ jobs:
             framework: net5.0
           - dotnet: 6.0
             framework: net6.0
+          - dotnet: 8.0
+            framework: net8.0
     name: NET ${{ matrix.dotnet }}
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +36,8 @@ jobs:
             2.0.x
             3.1.x
             5.0.x
-            6.0.x            
+            6.0.x
+            8.0.x            
       - id: list-installed-runtimes
         run: dotnet --list-runtimes
       - id: build-and-test

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        dotnet: [ '3.1', '5.0', '6.0']
+        dotnet: [ '3.1', '5.0', '6.0', '8.0']
         include:
           - dotnet: 3.1
             framework: netcoreapp3.1
@@ -18,6 +18,8 @@ jobs:
             framework: net5.0
           - dotnet: 6.0
             framework: net6.0
+          - dotnet: 8.0
+            framework: net8.0
     name: NET ${{ matrix.dotnet }}
     steps:
       - uses: actions/checkout@v2
@@ -34,6 +36,7 @@ jobs:
             3.1.x
             5.0.x
             6.0.x
+            8.0.x
       - id: list-installed-runtimes
         run: dotnet --list-runtimes
       - id: build-and-test

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - id: setup-net-2_0-3_1-5_0
+      - id: setup-net-2_0-3_1-5_0-6_0-8_0
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: |
@@ -19,6 +19,7 @@ jobs:
             3.1.x
             5.0.x
             6.0.x
+            8.0.x
       - id: list-installed-runtimes
         run: dotnet --list-runtimes
       - id: build-solution

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,9 +42,18 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: |
+          3.1.x
+          5.0.x
+          6.0.x
+          8.0.x
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0",
+    "version": "8.0.420",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/src/CheckoutSdk.Extensions/CheckoutSdk.Extensions.csproj
+++ b/src/CheckoutSdk.Extensions/CheckoutSdk.Extensions.csproj
@@ -13,7 +13,7 @@
     <PackageTags>Checkout.com;payments;gateway;sdk</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/checkout/checkout-sdk-net</RepositoryUrl>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>CheckoutSDK.Extensions.Configuration</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
@@ -30,6 +30,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CheckoutSdk/AbstractCheckoutSdkBuilder.cs
+++ b/src/CheckoutSdk/AbstractCheckoutSdkBuilder.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Text.RegularExpressions;
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
 using Microsoft.Extensions.Logging;
 #endif
 
@@ -32,7 +32,7 @@ namespace Checkout
             return this;
         }
 
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
         public AbstractCheckoutSdkBuilder<T> LogProvider(ILoggerFactory loggerFactory)
         {
             Checkout.LogProvider.SetLogFactory(loggerFactory);

--- a/src/CheckoutSdk/AgenticCommerce/AgenticCommerceClient.cs
+++ b/src/CheckoutSdk/AgenticCommerce/AgenticCommerceClient.cs
@@ -14,7 +14,7 @@ namespace Checkout.AgenticCommerce
         {
         }
 
-        public Task<DelegatedPaymentResponse> CreateDelegatedPayment(DelegatedPaymentRequest request,
+        public Task<DelegatedPaymentResponse> CreateDelegatedPaymentToken(DelegatedPaymentRequest request,
             DelegatedPaymentHeaders headers,
             CancellationToken cancellationToken = default)
         {

--- a/src/CheckoutSdk/AgenticCommerce/IAgenticCommerceClient.cs
+++ b/src/CheckoutSdk/AgenticCommerce/IAgenticCommerceClient.cs
@@ -19,7 +19,7 @@ namespace Checkout.AgenticCommerce
         /// <param name="headers">The required authentication headers (Signature and Timestamp)</param>
         /// <param name="cancellationToken">A cancellation token for the operation</param>
         /// <returns>The created delegated payment token</returns>
-        Task<DelegatedPaymentResponse> CreateDelegatedPayment(DelegatedPaymentRequest request,
+        Task<DelegatedPaymentResponse> CreateDelegatedPaymentToken(DelegatedPaymentRequest request,
             DelegatedPaymentHeaders headers,
             CancellationToken cancellationToken = default);
     }

--- a/src/CheckoutSdk/ApiClient.cs
+++ b/src/CheckoutSdk/ApiClient.cs
@@ -1,4 +1,4 @@
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
 using Microsoft.Extensions.Logging;
 using System.Web;
 #endif
@@ -18,7 +18,7 @@ namespace Checkout
 {
     public class ApiClient : IApiClient
     {
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
         private readonly ILogger _log = LogProvider.GetLogger(typeof(ApiClient));
 #endif
 
@@ -216,7 +216,7 @@ namespace Checkout
                 {
                     var queryString = string.Join("&",
                         parameters.Select(kvp =>
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
                             $"{HttpUtility.UrlEncode(kvp.Key)}={HttpUtility.UrlEncode(kvp.Value)}"));
 #else
                             $"{WebUtility.UrlEncode(kvp.Key)}={WebUtility.UrlEncode(kvp.Value)}"));
@@ -293,7 +293,7 @@ namespace Checkout
 
             var pathUri = new Uri(_baseUri, path);
             var httpRequest = new HttpRequestMessage(httpMethod, pathUri) { Content = httpContent };
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
             _log.LogInformation(@"{HttpMethod}: {Path}", httpMethod, path);
 #endif
 

--- a/src/CheckoutSdk/CheckoutSdk.csproj
+++ b/src/CheckoutSdk/CheckoutSdk.csproj
@@ -16,15 +16,15 @@
     <PackageTags>Checkout.com;payments;gateway;sdk</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/checkout/checkout-sdk-net</RepositoryUrl>
-    <TargetFrameworks>net6.0;net5.0;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>Checkout</RootNamespace>
     <PackageReleaseNotes>
     </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup Label="Global Package References">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -41,6 +41,10 @@
 
   <ItemGroup Label="NET 5 Package References" Condition=" '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Label="NET 8 Package References" Condition=" '$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CheckoutSdk/LogProvider.cs
+++ b/src/CheckoutSdk/LogProvider.cs
@@ -1,4 +1,4 @@
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;

--- a/src/CheckoutSdk/OAuthSdkCredentials.cs
+++ b/src/CheckoutSdk/OAuthSdkCredentials.cs
@@ -1,4 +1,4 @@
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
 using Microsoft.Extensions.Logging;
 #endif
 using System;
@@ -10,7 +10,7 @@ namespace Checkout
 {
     public sealed class OAuthSdkCredentials : SdkCredentials
     {
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
         private readonly ILogger _log = LogProvider.GetLogger(typeof(OAuthSdkCredentials));
 #endif
         private readonly string _clientId;
@@ -71,7 +71,7 @@ namespace Checkout
 
         private OAuthServiceResponse Request()
         {
-#if (NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER)
+#if NET5_0_OR_GREATER || NETSTANDARD2_0
             _log.LogInformation("requesting OAuth token using client_credentials flow");
 #endif
             try

--- a/test/CheckoutSdkTest/Accounts/AccountsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Accounts/AccountsIntegrationTest.cs
@@ -438,9 +438,9 @@ namespace Checkout.Accounts
                 .RetrievePaymentInstrumentDetails(entityResponse.Id, instrumentResponse.Id);
             instrumentDetails.ShouldNotBeNull();
             instrumentDetails.Id.ShouldNotBeNull();
-            instrumentDetails.Status.ShouldNotBeNull();
+            instrumentDetails.Status.ShouldNotBe(default);
             instrumentDetails.Label.ShouldNotBeNull();
-            instrumentDetails.Type.ShouldNotBeNull();
+            instrumentDetails.Type.ShouldNotBe(default);
             instrumentDetails.Currency.ShouldNotBeNull();
             instrumentDetails.Country.ShouldNotBeNull();
             instrumentDetails.Document.ShouldNotBeNull();
@@ -506,9 +506,9 @@ namespace Checkout.Accounts
                 .RetrievePaymentInstrumentDetails(entityResponse.Id, instrumentResponse.Id);
             instrumentDetails.ShouldNotBeNull();
             instrumentDetails.Id.ShouldNotBeNull();
-            instrumentDetails.Status.ShouldNotBeNull();
+            instrumentDetails.Status.ShouldNotBe(default);
             instrumentDetails.Label.ShouldNotBeNull();
-            instrumentDetails.Type.ShouldNotBeNull();
+            instrumentDetails.Type.ShouldNotBe(default);
             instrumentDetails.Currency.ShouldNotBeNull();
             instrumentDetails.Country.ShouldNotBeNull();
             instrumentDetails.Document.ShouldNotBeNull();
@@ -682,7 +682,7 @@ namespace Checkout.Accounts
             response.Data.ShouldNotBeNull();
             response.Data.Count.ShouldBeGreaterThan(0);
             response.Data.First().Id.ShouldNotBeNull();
-            response.Data.First().Type.ShouldNotBeNull();
+            response.Data.First().Type.ShouldNotBe(default);
         }
 
         private void ValidateReserveRuleResponse(ReserveRuleResponse response, ReserveRuleRequest originalRequest)

--- a/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceClientTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceClientTest.cs
@@ -51,7 +51,7 @@ namespace Checkout.AgenticCommerce
                 .ReturnsAsync(expectedResponse);
 
             IAgenticCommerceClient client = new AgenticCommerceClient(_apiClient.Object, _configuration.Object);
-            var response = await client.CreateDelegatedPayment(request, headers);
+            var response = await client.CreateDelegatedPaymentToken(request, headers);
 
             response.ShouldNotBeNull();
             response.Id.ShouldBe("vt_abc123def456ghi789");
@@ -63,7 +63,7 @@ namespace Checkout.AgenticCommerce
         {
             IAgenticCommerceClient client = new AgenticCommerceClient(_apiClient.Object, _configuration.Object);
             var exception = await Should.ThrowAsync<CheckoutArgumentException>(
-                async () => await client.CreateDelegatedPayment(null, new DelegatedPaymentHeaders()));
+                async () => await client.CreateDelegatedPaymentToken(null, new DelegatedPaymentHeaders()));
             exception.ShouldBeOfType<CheckoutArgumentException>();
         }
 
@@ -72,7 +72,7 @@ namespace Checkout.AgenticCommerce
         {
             IAgenticCommerceClient client = new AgenticCommerceClient(_apiClient.Object, _configuration.Object);
             var exception = await Should.ThrowAsync<CheckoutArgumentException>(
-                async () => await client.CreateDelegatedPayment(CreateValidDelegatedPaymentRequest(), null));
+                async () => await client.CreateDelegatedPaymentToken(CreateValidDelegatedPaymentRequest(), null));
             exception.ShouldBeOfType<CheckoutArgumentException>();
         }
 
@@ -94,7 +94,7 @@ namespace Checkout.AgenticCommerce
                 .ReturnsAsync(expectedResponse);
 
             IAgenticCommerceClient client = new AgenticCommerceClient(_apiClient.Object, _configuration.Object);
-            var response = await client.CreateDelegatedPayment(request, headers, cancellationToken);
+            var response = await client.CreateDelegatedPaymentToken(request, headers, cancellationToken);
 
             response.ShouldNotBeNull();
             response.Id.ShouldBe("vt_test123");

--- a/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceIntegrationTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceIntegrationTest.cs
@@ -50,11 +50,11 @@ namespace Checkout.AgenticCommerce
                 Signature = "computed-hmac-sha256-base64-signature"
             };
 
-            var response = await DefaultApi.AgenticCommerceClient().CreateDelegatedPayment(request, headers);
+            var response = await DefaultApi.AgenticCommerceClient().CreateDelegatedPaymentToken(request, headers);
 
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
-            response.Created.ShouldNotBeNull();
+            response.Created.ShouldNotBe(default);
             response.Metadata.ShouldNotBeNull();
         }
     }

--- a/test/CheckoutSdkTest/AgenticCommerce/DelegatedPaymentResponseSerializationTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/DelegatedPaymentResponseSerializationTest.cs
@@ -35,7 +35,7 @@ namespace Checkout.AgenticCommerce
 
             response.ShouldNotBeNull();
             response.Id.ShouldBe("vt_abc123def456ghi789");
-            response.Created.ShouldNotBeNull();
+            response.Created.ShouldNotBe(default);
             response.Metadata.ShouldNotBeNull();
             response.Metadata["psp"].ShouldBe("checkout.com");
         }

--- a/test/CheckoutSdkTest/Apm/Previous/Klarna/KlarnaIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Apm/Previous/Klarna/KlarnaIntegrationTest.cs
@@ -60,7 +60,7 @@ namespace Checkout.Apm.Previous.Klarna
             creditSession.PurchaseCountry.ShouldNotBeNull();
             creditSession.Currency.ShouldNotBeNull();
             creditSession.Locale.ShouldNotBeNull();
-            creditSession.Amount.ShouldNotBeNull();
+            creditSession.Amount.ShouldNotBe(0);
             creditSession.TaxAmount.ShouldNotBeNull();
             creditSession.Products.ShouldNotBeNull();
             foreach (var creditSessionProduct in creditSession.Products)

--- a/test/CheckoutSdkTest/Authentification/Standalone/AuthenticationClientTest.cs
+++ b/test/CheckoutSdkTest/Authentification/Standalone/AuthenticationClientTest.cs
@@ -95,7 +95,7 @@ namespace Checkout.Authentification.Standalone
 
             getSessionResponse.ShouldNotBeNull();
             getSessionResponse.Accepted.ShouldBeNull();
-            getSessionResponse.Created.ShouldNotBeNull();
+            getSessionResponse.Created.ShouldNotBe(default);
             getSessionResponse.Created.Acs.ChallengeCancelReasonCode.ShouldNotBeNull();
             getSessionResponse.Created.SchemeInfo.ShouldNotBeNull();
             getSessionResponse.Created.SchemeInfo.Name.ShouldNotBeNull();
@@ -127,8 +127,8 @@ namespace Checkout.Authentification.Standalone
 
             getSessionResponse.ShouldNotBeNull();
             getSessionResponse.Accepted.ShouldNotBeNull();
-            getSessionResponse.Accepted.AuthenticationDate.ShouldNotBeNull();
-            getSessionResponse.Accepted.ChallengeIndicator.ShouldNotBeNull();
+            getSessionResponse.Accepted.AuthenticationDate.ShouldNotBe(default);
+            getSessionResponse.Accepted.ChallengeIndicator.ShouldNotBe(default);
             getSessionResponse.Created.ShouldBeNull();
         }
 
@@ -180,9 +180,9 @@ namespace Checkout.Authentification.Standalone
 
             getSessionResponse.ShouldNotBeNull();
             getSessionResponse.Exemption.ShouldNotBeNull();
-            getSessionResponse.AuthenticationDate.ShouldNotBeNull();
-            getSessionResponse.FlowType.ShouldNotBeNull();
-            getSessionResponse.ChallengeIndicator.ShouldNotBeNull();
+            getSessionResponse.AuthenticationDate.ShouldNotBe(default);
+            getSessionResponse.FlowType.ShouldNotBe(default);
+            getSessionResponse.ChallengeIndicator.ShouldNotBe(default);
             getSessionResponse.SchemeInfo.ShouldNotBeNull();
         }
 

--- a/test/CheckoutSdkTest/Authentification/Standalone/CompleteSessionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Authentification/Standalone/CompleteSessionsIntegrationTest.cs
@@ -24,7 +24,7 @@ namespace Checkout.Authentification.Standalone
 
             created.Id.ShouldNotBeNull();
             created.SessionSecret.ShouldNotBeNull();
-            created.Amount.ShouldNotBeNull();
+            created.Amount.ShouldNotBe(0);
             created.Card.ShouldNotBeNull();
             created.AuthenticationType.ShouldBe(AuthenticationType.Regular);
             created.AuthenticationCategory.ShouldBe(AuthenticationCategoryType.Payment);

--- a/test/CheckoutSdkTest/Authentification/Standalone/RequestAndGetSessionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Authentification/Standalone/RequestAndGetSessionsIntegrationTest.cs
@@ -23,13 +23,13 @@ namespace Checkout.Authentification.Standalone
                 await CreateNonHostedSession(browserSession, category, challengeIndicator, transactionType);
 
             sessionResponse.ShouldNotBeNull();
-            sessionResponse.Created.ShouldNotBeNull();
+            sessionResponse.Created.ShouldNotBe(default);
 
             var response = sessionResponse.Created;
             response.Id.ShouldNotBeNull();
             response.SessionSecret.ShouldNotBeNull();
             response.TransactionId.ShouldNotBeNull();
-            response.Amount.ShouldNotBeNull();
+            response.Amount.ShouldNotBe(0);
             response.Certificates.ShouldNotBeNull();
             response.Ds.ShouldNotBeNull();
             response.Acs.ShouldNotBeNull();
@@ -42,7 +42,7 @@ namespace Checkout.Authentification.Standalone
             response.NextActions[0].ShouldBe(NextActionsType.ChallengeCardholder);
             response.TransactionType.ShouldBe(transactionType);
             response.ResponseCode.ShouldBe(ResponseCodeType.C);
-            response.AuthenticationDate.ShouldNotBeNull();
+            response.AuthenticationDate.ShouldNotBe(default);
 
             response.GetSelfLink().ShouldNotBeNull();
             response.GetLink("callback_url").ShouldNotBeNull();
@@ -55,7 +55,7 @@ namespace Checkout.Authentification.Standalone
             getSessionResponse.Id.ShouldNotBeNull();
             getSessionResponse.SessionSecret.ShouldNotBeNull();
             getSessionResponse.TransactionId.ShouldNotBeNull();
-            getSessionResponse.Amount.ShouldNotBeNull();
+            getSessionResponse.Amount.ShouldNotBe(0);
             getSessionResponse.Certificates.ShouldNotBeNull();
             getSessionResponse.Ds.ShouldNotBeNull();
             getSessionResponse.Card.ShouldNotBeNull();
@@ -67,7 +67,7 @@ namespace Checkout.Authentification.Standalone
             getSessionResponse.NextActions[0].ShouldBe(NextActionsType.ChallengeCardholder);
             getSessionResponse.TransactionType.ShouldBe(transactionType);
             getSessionResponse.ResponseCode.ShouldBe(ResponseCodeType.C);
-            response.AuthenticationDate.ShouldNotBeNull();
+            response.AuthenticationDate.ShouldNotBe(default);
 
             getSessionResponse.GetSelfLink().ShouldNotBeNull();
             getSessionResponse.GetLink("callback_url").ShouldNotBeNull();
@@ -81,7 +81,7 @@ namespace Checkout.Authentification.Standalone
 
             getSessionSecretSessionResponse.Id.ShouldNotBeNull();
             getSessionSecretSessionResponse.TransactionId.ShouldNotBeNull();
-            getSessionSecretSessionResponse.Amount.ShouldNotBeNull();
+            getSessionSecretSessionResponse.Amount.ShouldNotBe(0);
             getSessionSecretSessionResponse.Ds.ShouldNotBeNull();
             getSessionSecretSessionResponse.Acs.ShouldNotBeNull();
             getSessionSecretSessionResponse.Card.ShouldNotBeNull();
@@ -117,7 +117,7 @@ namespace Checkout.Authentification.Standalone
             response.Id.ShouldNotBeNull();
             response.SessionSecret.ShouldNotBeNull();
             response.TransactionId.ShouldNotBeNull();
-            response.Amount.ShouldNotBeNull();
+            response.Amount.ShouldNotBe(0);
             response.Card.ShouldNotBeNull();
 
             response.AuthenticationType.ShouldBe(AuthenticationType.Regular);
@@ -137,7 +137,7 @@ namespace Checkout.Authentification.Standalone
             getSessionResponse.Id.ShouldNotBeNull();
             getSessionResponse.SessionSecret.ShouldNotBeNull();
             getSessionResponse.TransactionId.ShouldNotBeNull();
-            getSessionResponse.Amount.ShouldNotBeNull();
+            getSessionResponse.Amount.ShouldNotBe(0);
             getSessionResponse.Certificates.ShouldNotBeNull();
             getSessionResponse.Ds.ShouldNotBeNull();
             getSessionResponse.Acs.ShouldBeNull();
@@ -150,7 +150,7 @@ namespace Checkout.Authentification.Standalone
             getSessionResponse.NextActions[0].ShouldBe(NextActionsType.CollectChannelData);
             getSessionResponse.TransactionType.ShouldBe(transactionType);
             getSessionResponse.ResponseCode.ShouldBeNull();
-            getSessionResponse.AuthenticationDate.ShouldNotBeNull();
+            getSessionResponse.AuthenticationDate.ShouldNotBe(default);
 
             getSessionResponse.GetSelfLink().ShouldNotBeNull();
             getSessionResponse.GetLink("callback_url").ShouldNotBeNull();
@@ -169,13 +169,13 @@ namespace Checkout.Authentification.Standalone
                 await CreateNonHostedSession(merchantInitiatedSession, category, challengeIndicator, transactionType);
 
             sessionResponse.ShouldNotBeNull();
-            sessionResponse.Created.ShouldNotBeNull();
+            sessionResponse.Created.ShouldNotBe(default);
 
             var response = sessionResponse.Created;
             response.Id.ShouldNotBeNull();
             response.SessionSecret.ShouldNotBeNull();
             response.TransactionId.ShouldNotBeNull();
-            response.Amount.ShouldNotBeNull();
+            response.Amount.ShouldNotBe(0);
             response.Certificates.ShouldNotBeNull();
             response.Ds.ShouldNotBeNull();
             response.Card.ShouldNotBeNull();
@@ -198,7 +198,7 @@ namespace Checkout.Authentification.Standalone
             getSessionResponse.Id.ShouldNotBeNull();
             getSessionResponse.SessionSecret.ShouldNotBeNull();
             getSessionResponse.TransactionId.ShouldNotBeNull();
-            getSessionResponse.Amount.ShouldNotBeNull();
+            getSessionResponse.Amount.ShouldNotBe(0);
             getSessionResponse.Certificates.ShouldNotBeNull();
             getSessionResponse.Ds.ShouldNotBeNull();
             getSessionResponse.Acs.ShouldBeNull();
@@ -211,7 +211,7 @@ namespace Checkout.Authentification.Standalone
             getSessionResponse.NextActions[0].ShouldBe(NextActionsType.Complete);
             getSessionResponse.TransactionType.ShouldBe(transactionType);
             getSessionResponse.ResponseCode.ShouldBe(ResponseCodeType.U);
-            getSessionResponse.AuthenticationDate.ShouldNotBeNull();
+            getSessionResponse.AuthenticationDate.ShouldNotBe(default);
 
             getSessionResponse.GetSelfLink().ShouldNotBeNull();
             getSessionResponse.GetLink("callback_url").ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Authentification/Standalone/UpdateSessionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Authentification/Standalone/UpdateSessionsIntegrationTest.cs
@@ -33,7 +33,7 @@ namespace Checkout.Authentification.Standalone
             created.Id.ShouldNotBeNull();
             created.SessionSecret.ShouldNotBeNull();
             created.TransactionId.ShouldNotBeNull();
-            created.Amount.ShouldNotBeNull();
+            created.Amount.ShouldNotBe(0);
             created.AuthenticationType.ShouldBe(AuthenticationType.Regular);
             created.AuthenticationCategory.ShouldBe(AuthenticationCategoryType.Payment);
             created.NextActions.Count.ShouldBe(1);
@@ -61,7 +61,7 @@ namespace Checkout.Authentification.Standalone
                 updated.SessionSecret.ShouldNotBeNull();
 
             updated.Id.ShouldNotBeNull();
-            updated.Amount.ShouldNotBeNull();
+            updated.Amount.ShouldNotBe(0);
             updated.Card.ShouldNotBeNull();
             updated.AuthenticationType.ShouldBe(AuthenticationType.Regular);
             updated.AuthenticationCategory.ShouldBe(AuthenticationCategoryType.Payment);
@@ -86,7 +86,7 @@ namespace Checkout.Authentification.Standalone
             created.Id.ShouldNotBeNull();
             created.SessionSecret.ShouldNotBeNull();
             created.TransactionId.ShouldNotBeNull();
-            created.Amount.ShouldNotBeNull();
+            created.Amount.ShouldNotBe(0);
             created.Card.ShouldNotBeNull();
             created.AuthenticationType.ShouldBe(AuthenticationType.Regular);
             created.AuthenticationCategory.ShouldBe(AuthenticationCategoryType.Payment);
@@ -104,7 +104,7 @@ namespace Checkout.Authentification.Standalone
             updated.ShouldNotBeNull();
             updated.Id.ShouldNotBeNull();
             updated.TransactionId.ShouldNotBeNull();
-            updated.Amount.ShouldNotBeNull();
+            updated.Amount.ShouldNotBe(0);
             updated.Card.ShouldNotBeNull();
             updated.AuthenticationType.ShouldBe(AuthenticationType.Regular);
             updated.AuthenticationCategory.ShouldBe(AuthenticationCategoryType.Payment);

--- a/test/CheckoutSdkTest/CheckoutSdkIntegrationTest.cs
+++ b/test/CheckoutSdkTest/CheckoutSdkIntegrationTest.cs
@@ -83,7 +83,11 @@ namespace Checkout
                 CancellationToken cancellationToken)
             {
                 var response = new HttpResponseMessage();
+#if NETSTANDARD2_0
+                response.StatusCode = (HttpStatusCode)508;
+#else
                 response.StatusCode = HttpStatusCode.LoopDetected;
+#endif
                 response.Content = new StringContent("{}", Encoding.UTF8, "application/json");
                 return Task.Factory.StartNew(() => response, cancellationToken);
             }

--- a/test/CheckoutSdkTest/CheckoutSdkTest.csproj
+++ b/test/CheckoutSdkTest/CheckoutSdkTest.csproj
@@ -3,7 +3,8 @@
     <PropertyGroup>
         <RootNamespace>Checkout</RootNamespace>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;net5.0;netstandard2.0</TargetFrameworks>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -39,6 +40,12 @@
         </PackageReference>
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="Shouldly" Version="3.0.1" />
+    </ItemGroup>
+
+    <!-- Additional packages for netstandard2.0 to support C# 8.0 features -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+        <PackageReference Include="IndexRange" Version="1.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/CheckoutSdkTest/CheckoutSdkTest.csproj
+++ b/test/CheckoutSdkTest/CheckoutSdkTest.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <RootNamespace>Checkout</RootNamespace>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net8.0;net6.0;net5.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 

--- a/test/CheckoutSdkTest/CheckoutSdkTest.csproj
+++ b/test/CheckoutSdkTest/CheckoutSdkTest.csproj
@@ -16,12 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="4.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="4.0.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="NLog" Version="4.7.11" />
         <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />

--- a/test/CheckoutSdkTest/Disputes/DisputesIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Disputes/DisputesIntegrationTest.cs
@@ -46,7 +46,7 @@ namespace Checkout.Disputes
             fileDetails.ShouldNotBeNull();
             fileDetails.Id.ShouldNotBeNull();
             fileDetails.Filename.ShouldNotBeNull();
-            fileDetails.Purpose.ShouldNotBeNull();
+            fileDetails.Purpose.ShouldNotBe(default);
             fileDetails.Size.ShouldNotBeNull();
             fileDetails.UploadedOn.ShouldNotBeNull();
         }

--- a/test/CheckoutSdkTest/Disputes/Previous/DisputesIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Disputes/Previous/DisputesIntegrationTest.cs
@@ -20,8 +20,8 @@ namespace Checkout.Disputes.Previous
             response.Limit.ShouldBe(250);
             response.Skip.ShouldNotBeNull();
             response.TotalCount.ShouldNotBeNull();
-            response.To.ShouldNotBeNull();
-            response.From.ShouldNotBeNull();
+            response.To.ShouldNotBe(default);
+            response.From.ShouldNotBe(default);
 
             if (response.TotalCount > 0)
             {
@@ -51,7 +51,7 @@ namespace Checkout.Disputes.Previous
             fileDetails.ShouldNotBeNull();
             fileDetails.Id.ShouldNotBeNull();
             fileDetails.Filename.ShouldNotBeNull();
-            fileDetails.Purpose.ShouldNotBeNull();
+            fileDetails.Purpose.ShouldNotBe(default);
             fileDetails.Size.ShouldNotBeNull();
             fileDetails.UploadedOn.ShouldNotBeNull();
         }

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/ApplePay/ApplePayIntegrationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/ApplePay/ApplePayIntegrationTest.cs
@@ -152,7 +152,7 @@ namespace Checkout.HandlePaymentsAndPayouts.ApplePay
             response.Content.ShouldContain("END CERTIFICATE REQUEST");
             
             // Verify the protocol version was respected (indirectly through successful response)
-            request.ProtocolVersion.ShouldNotBeNull();
+            request.ProtocolVersion.ShouldNotBe(default);
         }
     }
 }

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/ApplePay/ApplePayIntegrationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/ApplePay/ApplePayIntegrationTest.cs
@@ -151,8 +151,8 @@ namespace Checkout.HandlePaymentsAndPayouts.ApplePay
             response.Content.ShouldContain("BEGIN CERTIFICATE REQUEST");
             response.Content.ShouldContain("END CERTIFICATE REQUEST");
             
-            // Verify the protocol version was respected (indirectly through successful response)
-            request.ProtocolVersion.ShouldNotBe(default);
+            // Verify the protocol version is set to a valid value
+            request.ProtocolVersion.ShouldBeOneOf(ProtocolVersions.EcV1, ProtocolVersions.RsaV1);
         }
     }
 }

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Flow/FlowIntegrationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Flow/FlowIntegrationTest.cs
@@ -56,7 +56,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow
             // Assert
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNull();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         [Fact(Skip = "This test requires a valid merchant configuration for Flow")]
@@ -71,7 +71,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow
             // Assert
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNull();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
         
         [Fact]

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/HandlePaymentsAndPayoutsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/HandlePaymentsAndPayoutsIntegrationTest.cs
@@ -35,17 +35,17 @@ namespace Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments
             if (response.Created != null)
             {
                 response.Created.Id.ShouldNotBeNull();
-                response.Created.Status.ShouldNotBeNull();
+                response.Created.Status.ShouldNotBe(default);
                 response.Created.Amount.ShouldBe(1000);
                 response.Created.Currency.ShouldBe(Currency.USD);
                 response.Created.Reference.ShouldBe("ORD-5023-4E89");
                 response.Created.Source.ShouldNotBeNull();
-                response.Created.Source.Type.ShouldNotBeNull();
+                response.Created.Source.Type.ShouldNotBe(default);
             }
             else if (response.Accepted != null)
             {
                 response.Accepted.Id.ShouldNotBeNull();
-                response.Accepted.Status.ShouldNotBeNull();
+                response.Accepted.Status.ShouldNotBe(default);
                 response.Accepted.Reference.ShouldBe("ORD-5023-4E89");
             }
             else

--- a/test/CheckoutSdkTest/Identities/AmlScreening/AmlScreeningClientTest.cs
+++ b/test/CheckoutSdkTest/Identities/AmlScreening/AmlScreeningClientTest.cs
@@ -191,7 +191,7 @@ namespace Checkout.Identities.AmlScreening
         {
             response.Id.ShouldNotBeNullOrEmpty();
             response.ApplicantId.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBe(default);
+            response.Status.ShouldBeOneOf(AmlScreeningStatus.Created, AmlScreeningStatus.ScreeningInProgress, AmlScreeningStatus.Approved, AmlScreeningStatus.Declined, AmlScreeningStatus.ReviewRequired);
             response.SearchParameters.ShouldNotBeNull();
             response.SearchParameters.ConfigurationIdentifier.ShouldNotBeNullOrEmpty();
             response.Monitored.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Identities/AmlScreening/AmlScreeningClientTest.cs
+++ b/test/CheckoutSdkTest/Identities/AmlScreening/AmlScreeningClientTest.cs
@@ -191,7 +191,7 @@ namespace Checkout.Identities.AmlScreening
         {
             response.Id.ShouldNotBeNullOrEmpty();
             response.ApplicantId.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             response.SearchParameters.ShouldNotBeNull();
             response.SearchParameters.ConfigurationIdentifier.ShouldNotBeNullOrEmpty();
             response.Monitored.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Identities/AmlScreening/AmlScreeningIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Identities/AmlScreening/AmlScreeningIntegrationTest.cs
@@ -167,7 +167,7 @@ namespace Checkout.Identities.AmlScreening
             response.Id.ShouldStartWith("scr_");
             response.ApplicantId.ShouldNotBeNullOrEmpty(); 
             response.ApplicantId.ShouldStartWith("aplt_");
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             response.SearchParameters.ShouldNotBeNull();
             response.SearchParameters.ConfigurationIdentifier.ShouldNotBeNullOrEmpty();
             response.CreatedOn.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Identities/FaceAuthentication/FaceAuthenticationClientTest.cs
+++ b/test/CheckoutSdkTest/Identities/FaceAuthentication/FaceAuthenticationClientTest.cs
@@ -368,14 +368,14 @@ namespace Checkout.Identities.FaceAuthentication
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldNotBeNullOrEmpty();
             response.ApplicantId.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         private static void ValidateFaceAuthenticationAttemptResponse(FaceAuthenticationAttemptResponse response)
         {
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         private static void ValidateFaceAuthenticationAttemptsResponse(FaceAuthenticationAttemptsResponse response)

--- a/test/CheckoutSdkTest/Identities/FaceAuthentication/FaceAuthenticationIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Identities/FaceAuthentication/FaceAuthenticationIntegrationTest.cs
@@ -184,7 +184,7 @@ namespace Checkout.Identities.FaceAuthentication
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldBe(request.UserJourneyId);
             response.ApplicantId.ShouldBe(request.ApplicantId);
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             
             if (response.CreatedOn.HasValue)
             {
@@ -198,7 +198,7 @@ namespace Checkout.Identities.FaceAuthentication
             retrieved.Id.ShouldBe(created.Id);
             retrieved.UserJourneyId.ShouldBe(created.UserJourneyId);
             retrieved.ApplicantId.ShouldBe(created.ApplicantId);
-            retrieved.Status.ShouldNotBeNull();
+            retrieved.Status.ShouldNotBe(default);
         }
 
         private static void ValidateAnonymizedFaceAuthentication(FaceAuthenticationResponse response)
@@ -211,7 +211,7 @@ namespace Checkout.Identities.FaceAuthentication
         {
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             
             if (response.RedirectUrl != null)
             {
@@ -231,7 +231,7 @@ namespace Checkout.Identities.FaceAuthentication
         {
             retrieved.ShouldNotBeNull();
             retrieved.Id.ShouldBe(created.Id);
-            retrieved.Status.ShouldNotBeNull();
+            retrieved.Status.ShouldNotBe(default);
         }
 
         private static string GenerateRandomId()

--- a/test/CheckoutSdkTest/Identities/IdDocumentVerification/IdDocumentVerificationClientTest.cs
+++ b/test/CheckoutSdkTest/Identities/IdDocumentVerification/IdDocumentVerificationClientTest.cs
@@ -416,14 +416,14 @@ namespace Checkout.Identities.IdDocumentVerification
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldNotBeNullOrEmpty();
             response.ApplicantId.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         private static void ValidateIdDocumentVerificationAttemptResponse(IdDocumentVerificationAttemptResponse response)
         {
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         private static void ValidateIdDocumentVerificationAttemptsResponse(IdDocumentVerificationAttemptsResponse response)

--- a/test/CheckoutSdkTest/Identities/IdDocumentVerification/IdDocumentVerificationClientTest.cs
+++ b/test/CheckoutSdkTest/Identities/IdDocumentVerification/IdDocumentVerificationClientTest.cs
@@ -416,7 +416,7 @@ namespace Checkout.Identities.IdDocumentVerification
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldNotBeNullOrEmpty();
             response.ApplicantId.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBe(default);
+            response.Status.ShouldBeOneOf(IdDocumentVerificationStatus.Created, IdDocumentVerificationStatus.QualityChecksInProgress, IdDocumentVerificationStatus.ChecksInProgress);
         }
 
         private static void ValidateIdDocumentVerificationAttemptResponse(IdDocumentVerificationAttemptResponse response)

--- a/test/CheckoutSdkTest/Identities/IdDocumentVerification/IdDocumentVerificationIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Identities/IdDocumentVerification/IdDocumentVerificationIntegrationTest.cs
@@ -205,7 +205,7 @@ namespace Checkout.Identities.IdDocumentVerification
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldBe(request.UserJourneyId);
             response.ApplicantId.ShouldBe(request.ApplicantId);
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             
             if (response.DeclaredData != null && request.DeclaredData != null)
             {
@@ -224,7 +224,7 @@ namespace Checkout.Identities.IdDocumentVerification
             retrieved.Id.ShouldBe(created.Id);
             retrieved.UserJourneyId.ShouldBe(created.UserJourneyId);
             retrieved.ApplicantId.ShouldBe(created.ApplicantId);
-            retrieved.Status.ShouldNotBeNull();
+            retrieved.Status.ShouldNotBe(default);
         }
 
         private static void ValidateAnonymizedIdDocumentVerification(IdDocumentVerificationResponse response)
@@ -237,7 +237,7 @@ namespace Checkout.Identities.IdDocumentVerification
         {
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         private static void ValidateRetrievedIdDocumentVerificationAttempts(IdDocumentVerificationAttemptsResponse response, IdDocumentVerificationAttemptResponse createdAttempt)
@@ -252,7 +252,7 @@ namespace Checkout.Identities.IdDocumentVerification
         {
             retrieved.ShouldNotBeNull();
             retrieved.Id.ShouldBe(created.Id);
-            retrieved.Status.ShouldNotBeNull();
+            retrieved.Status.ShouldNotBe(default);
         }
 
         private static void ValidateIdDocumentVerificationReport(IdDocumentVerificationReportResponse response)

--- a/test/CheckoutSdkTest/Identities/IdentityVerification/IdentityVerificationClientTest.cs
+++ b/test/CheckoutSdkTest/Identities/IdentityVerification/IdentityVerificationClientTest.cs
@@ -534,7 +534,7 @@ namespace Checkout.Identities.IdentityVerification
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldNotBeNullOrEmpty();
             response.ApplicantId.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             response.RedirectUrl.ShouldNotBeNullOrEmpty();
         }
 
@@ -544,14 +544,14 @@ namespace Checkout.Identities.IdentityVerification
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldNotBeNullOrEmpty();
             response.ApplicantId.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         private static void ValidateIdentityVerificationAttemptResponse(IdentityVerificationAttemptResponse response)
         {
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
 
         private static void ValidateIdentityVerificationAttemptsResponse(IdentityVerificationAttemptsResponse response)

--- a/test/CheckoutSdkTest/Identities/IdentityVerification/IdentityVerificationIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Identities/IdentityVerification/IdentityVerificationIntegrationTest.cs
@@ -280,7 +280,7 @@ namespace Checkout.Identities.IdentityVerification
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldBe(request.UserJourneyId);
             response.ApplicantId.ShouldBe(request.ApplicantId);
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             response.RedirectUrl.ShouldBe(request.RedirectUrl);
 
             if (response.DeclaredData != null && request.DeclaredData != null)
@@ -300,7 +300,7 @@ namespace Checkout.Identities.IdentityVerification
             response.Id.ShouldNotBeNullOrEmpty();
             response.UserJourneyId.ShouldBe(request.UserJourneyId);
             response.ApplicantId.ShouldBe(request.ApplicantId);
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
 
             if (response.DeclaredData != null && request.DeclaredData != null)
             {
@@ -319,7 +319,7 @@ namespace Checkout.Identities.IdentityVerification
             retrieved.Id.ShouldBe(created.Id);
             retrieved.UserJourneyId.ShouldBe(created.UserJourneyId);
             retrieved.ApplicantId.ShouldBe(created.ApplicantId);
-            retrieved.Status.ShouldNotBeNull();
+            retrieved.Status.ShouldNotBe(default);
         }
 
         private static void ValidateRetrievedIdentityVerificationFromCreatedAndAttempt(IdentityVerificationResponse retrieved, IdentityVerificationAndAttemptResponse created)
@@ -328,7 +328,7 @@ namespace Checkout.Identities.IdentityVerification
             retrieved.Id.ShouldBe(created.Id);
             retrieved.UserJourneyId.ShouldBe(created.UserJourneyId);
             retrieved.ApplicantId.ShouldBe(created.ApplicantId);
-            retrieved.Status.ShouldNotBeNull();
+            retrieved.Status.ShouldNotBe(default);
         }
 
         private static void ValidateAnonymizedIdentityVerification(IdentityVerificationResponse response)
@@ -341,7 +341,7 @@ namespace Checkout.Identities.IdentityVerification
         {
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             
             if (response.RedirectUrl != null)
             {
@@ -361,7 +361,7 @@ namespace Checkout.Identities.IdentityVerification
         {
             retrieved.ShouldNotBeNull();
             retrieved.Id.ShouldBe(created.Id);
-            retrieved.Status.ShouldNotBeNull();
+            retrieved.Status.ShouldNotBe(default);
         }
 
         private static void ValidateIdentityVerificationReport(IdentityVerificationReportResponse response)

--- a/test/CheckoutSdkTest/Instruments/BankAccountFieldFormattingTest.cs
+++ b/test/CheckoutSdkTest/Instruments/BankAccountFieldFormattingTest.cs
@@ -37,7 +37,7 @@ namespace Checkout.Instruments
                 {
                     field.Id.ShouldNotBeNull();
                     field.Display.ShouldNotBeNull();
-                    field.Type.ShouldNotBeNull();
+                    field.Type.ShouldNotBe(default);
                 }
             }
         }

--- a/test/CheckoutSdkTest/Instruments/InstrumentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Instruments/InstrumentsIntegrationTest.cs
@@ -32,12 +32,12 @@ namespace Checkout.Instruments
             cardResponse.Bin.ShouldNotBeNull();
             cardResponse.IssuerCountry.ShouldNotBeNull();
             cardResponse.ProductId.ShouldNotBeNull();
-            cardResponse.ProductType.ShouldNotBeNull();
+            cardResponse.ProductType.ShouldNotBe(default);
             cardResponse.Customer.ShouldNotBeNull();
             cardResponse.AccountHolder.ShouldNotBeNull();
             cardResponse.AccountHolder.BillingAddress.ShouldNotBeNull();
             cardResponse.AccountHolder.Phone.ShouldNotBeNull();
-            cardResponse.CardType.ShouldNotBeNull();
+            cardResponse.CardType.ShouldNotBe(default);
             cardResponse.CardCategory.ShouldNotBeNull();
         }
         
@@ -152,7 +152,7 @@ namespace Checkout.Instruments
 
             cardResponse.AccountHolder.FirstName.ShouldBe("John");
             cardResponse.AccountHolder.LastName.ShouldBe("Doe");
-            cardResponse.CardType.ShouldNotBeNull();
+            cardResponse.CardType.ShouldNotBe(default);
             cardResponse.CardCategory.ShouldNotBeNull();
         }
 
@@ -225,9 +225,9 @@ namespace Checkout.Instruments
             createTokenInstrumentResponse.Bin.ShouldNotBeNull();
             createTokenInstrumentResponse.IssuerCountry.ShouldNotBeNull();
             createTokenInstrumentResponse.ProductId.ShouldNotBeNull();
-            createTokenInstrumentResponse.ProductType.ShouldNotBeNull();
+            createTokenInstrumentResponse.ProductType.ShouldNotBe(default);
             createTokenInstrumentResponse.Customer.ShouldNotBeNull();
-            createTokenInstrumentResponse.CardType.ShouldNotBeNull();
+            createTokenInstrumentResponse.CardType.ShouldNotBe(default);
             createTokenInstrumentResponse.CardCategory.ShouldNotBeNull();
             return createTokenInstrumentResponse;
         }

--- a/test/CheckoutSdkTest/Issuing/CardHolderAccessTokens/CardholderAccessTokenIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/CardHolderAccessTokens/CardholderAccessTokenIntegrationTest.cs
@@ -24,7 +24,7 @@ namespace Checkout.Issuing
 
             response.ShouldNotBeNull();
             response.AccessToken.ShouldNotBeNull();
-            response.TokenType.ShouldNotBeNull();
+            response.TokenType.ShouldNotBe(default);
             response.ExpiresIn.ShouldNotBeNull();
         }
     }

--- a/test/CheckoutSdkTest/Issuing/Cards/CardIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/Cards/CardIntegrationTest.cs
@@ -82,7 +82,7 @@ namespace Checkout.Issuing.Cards
             response.LastFour.ShouldNotBeNull();
             response.ExpiryMonth.ShouldNotBeNull();
             response.ExpiryYear.ShouldNotBeNull();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             response.DisplayName.ShouldNotBeNull();
             response.BillingCurrency.ShouldNotBeNull();
             response.IssuingCountry.ShouldNotBeNull();
@@ -116,7 +116,7 @@ namespace Checkout.Issuing.Cards
             response.LastFour.ShouldNotBeNull();
             response.ExpiryMonth.ShouldNotBeNull();
             response.ExpiryYear.ShouldNotBeNull();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             response.DisplayName.ShouldNotBeNull();
             response.BillingCurrency.ShouldNotBeNull();
             response.IssuingCountry.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Issuing/ControlGroups/ControlGroupsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/ControlGroups/ControlGroupsIntegrationTest.cs
@@ -88,7 +88,7 @@ namespace Checkout.Issuing.ControlGroups
             AssertControlGroupRemoved(response, createResponse.Id);
         }
 
-         [Fact]
+        [Fact]
         public async Task ControlGroupFlow_ShouldWorkEndToEnd()
         {
             // Arrange - Create a new cardholder and card for this flow test

--- a/test/CheckoutSdkTest/Issuing/DigitalCards/DigitalCardsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/DigitalCards/DigitalCardsIntegrationTest.cs
@@ -21,7 +21,7 @@ namespace Checkout.Issuing.DigitalCards
             response.Id.ShouldBe(digitalCardId);
             response.CardId.ShouldNotBeNullOrEmpty();
             response.LastFour.ShouldNotBeNullOrEmpty();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
         }
     }
 }

--- a/test/CheckoutSdkTest/Issuing/Transactions/TransactionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/Transactions/TransactionsIntegrationTest.cs
@@ -34,8 +34,8 @@ namespace Checkout.Issuing.Transactions
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNullOrEmpty();
             response.CreatedOn.ShouldNotBeNull();
-            response.Status.ShouldNotBeNull();
-            response.TransactionType.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
+            response.TransactionType.ShouldNotBe(default);
             response.Client.ShouldNotBeNull();
             response.Entity.ShouldNotBeNull();
             response.Card.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Metadata/MetadataIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Metadata/MetadataIntegrationTest.cs
@@ -97,7 +97,7 @@ namespace Checkout.Metadata
             response.IssuerCountry.ShouldBeOfType<CountryCode>();
             response.IssuerCountryName.ShouldNotBeNull();
             response.ProductId.ShouldNotBeNull();
-            response.ProductType.ShouldNotBeNull();
+            response.ProductType.ShouldNotBe(default);
         }
 
         private static async Task<string> RequestCardToken()

--- a/test/CheckoutSdkTest/PaymentMethods/PaymentMethodsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/PaymentMethods/PaymentMethodsIntegrationTest.cs
@@ -54,7 +54,7 @@ namespace Checkout.PaymentMethods
             foreach (var method in response.Methods)
             {
                 method.ShouldNotBeNull();
-                method.Type.ShouldNotBeNull();
+                method.Type.ShouldNotBe(default);
             }
         }
 
@@ -66,7 +66,7 @@ namespace Checkout.PaymentMethods
             foreach (var method in response.Methods)
             {
                 // Validate that each method has the expected structure
-                method.Type.ShouldNotBeNull();
+                method.Type.ShouldNotBe(default);
                 
                 // If partner merchant ID is provided, it should be valid
                 if (!string.IsNullOrEmpty(method.PartnerMerchantId))

--- a/test/CheckoutSdkTest/Payments/Hosted/HostedPaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Hosted/HostedPaymentsIntegrationTest.cs
@@ -36,7 +36,7 @@ namespace Checkout.Payments.Hosted
             getResponse.Id.ShouldNotBeNullOrEmpty();
             getResponse.Reference.ShouldNotBeNullOrEmpty();
             getResponse.Status.ShouldBe(HostedPaymentStatus.PaymentPending);
-            getResponse.Amount.ShouldNotBeNull();
+            getResponse.Amount.ShouldNotBe(0);
             getResponse.Billing.ShouldNotBeNull();
             getResponse.Currency.ShouldBe(Currency.GBP);
             getResponse.Customer.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Payments/Links/PaymentLinksIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Links/PaymentLinksIntegrationTest.cs
@@ -153,7 +153,7 @@ namespace Checkout.Payments.Links
             responseGet.CreatedOn.ShouldNotBeNull();
             responseGet.Currency.ShouldNotBeNull();
             responseGet.Customer.ShouldNotBeNull();
-            responseGet.Status.ShouldNotBeNull();
+            responseGet.Status.ShouldNotBe(default);
             responseGet.Reference.ShouldNotBeNullOrEmpty();
             responseGet.Description.ShouldNotBeNullOrEmpty();
             responseGet.Links.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Payments/PaymentActionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/PaymentActionsIntegrationTest.cs
@@ -25,7 +25,7 @@ namespace Checkout.Payments
                 paymentAction.Reference.ShouldNotBeNullOrEmpty();
                 paymentAction.ResponseCode.ShouldNotBeNullOrEmpty();
                 paymentAction.ResponseSummary.ShouldNotBeNullOrEmpty();
-                paymentAction.Type.ShouldNotBeNull();
+                paymentAction.Type.ShouldNotBe(default);
             }
         }
 

--- a/test/CheckoutSdkTest/Payments/PaymentAuthorizationsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/PaymentAuthorizationsIntegrationTest.cs
@@ -27,7 +27,7 @@ namespace Checkout.Payments
                 .IncrementPaymentAuthorization(paymentResponse.Id, authorizationRequest);
 
             authorizationResponse.ShouldNotBeNull();
-            authorizationResponse.Amount.ShouldNotBeNull();
+            authorizationResponse.Amount.ShouldNotBe(0);
             authorizationResponse.ActionId.ShouldNotBeNull();
             authorizationResponse.Currency.ShouldNotBeNull();
             authorizationResponse.Approved.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Payments/PayoutsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/PayoutsIntegrationTest.cs
@@ -86,7 +86,7 @@ namespace Checkout.Payments
             PayoutResponse response = await DefaultApi.PaymentsClient().RequestPayout(request);
             response.ShouldNotBeNull();
             response.Id.ShouldNotBeNull();
-            response.Status.ShouldNotBeNull();
+            response.Status.ShouldNotBe(default);
             response.Instruction.ShouldNotBeNull();
             response.Instruction.ValueDate.ShouldNotBeNull();
         }

--- a/test/CheckoutSdkTest/Payments/Previous/Hosted/HostedPaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Previous/Hosted/HostedPaymentsIntegrationTest.cs
@@ -27,7 +27,7 @@ namespace Checkout.Payments.Previous.Hosted
             getResponse.Id.ShouldNotBeNullOrEmpty();
             getResponse.Reference.ShouldNotBeNullOrEmpty();
             getResponse.Status.ShouldBe(HostedPaymentStatus.PaymentPending);
-            getResponse.Amount.ShouldNotBeNull();
+            getResponse.Amount.ShouldNotBe(0);
             getResponse.Billing.ShouldNotBeNull();
             getResponse.Currency.ShouldBe(Currency.GBP);
             getResponse.Customer.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Payments/Previous/PaymentActionsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/Previous/PaymentActionsIntegrationTest.cs
@@ -26,7 +26,7 @@ namespace Checkout.Payments.Previous
                 paymentAction.Reference.ShouldNotBeNullOrEmpty();
                 paymentAction.ResponseCode.ShouldNotBeNullOrEmpty();
                 paymentAction.ResponseSummary.ShouldNotBeNullOrEmpty();
-                paymentAction.Type.ShouldNotBeNull();
+                paymentAction.Type.ShouldNotBe(default);
             }
         }
 

--- a/test/CheckoutSdkTest/Payments/RequestApmPaymentsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Payments/RequestApmPaymentsIntegrationTest.cs
@@ -64,7 +64,7 @@ namespace Checkout.Payments
             var paymentResponse = await DefaultApi.PaymentsClient().RequestPayment(paymentRequest);
 
             paymentResponse.ShouldNotBeNull();
-            paymentResponse.Status.ShouldNotBeNull();
+            paymentResponse.Status.ShouldNotBe(default);
             paymentResponse.Reference.ShouldBe("REFERENCE");
             paymentResponse.Links.ShouldNotBeNull();
 
@@ -72,7 +72,7 @@ namespace Checkout.Payments
 
             payment.ShouldNotBeNull();
 
-            payment.Status.ShouldNotBeNull();
+            payment.Status.ShouldNotBe(default);
             payment.Links.ShouldNotBeNull();
 
             payment.Source.ShouldBeOfType(typeof(AlternativePaymentSourceResponse));

--- a/test/CheckoutSdkTest/Reporting/Financial/FinancialIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Reporting/Financial/FinancialIntegrationTest.cs
@@ -33,13 +33,13 @@ namespace Checkout.Financial
             ;
 
             response.ShouldNotBeNull();
-            if (!response.Data.IsNullOrEmpty())
+            if (response.Data?.Count > 0)
             {
                 foreach (var action in response.Data)
                 {
                     action.PaymentId.ShouldNotBeNull();
                     action.ActionId.ShouldNotBeNull();
-                    action.ActionType.ShouldNotBeNull();
+                    action.ActionType.ShouldNotBe(default);
                     action.EntityId.ShouldNotBeNull();
                     action.CurrencyAccountId.ShouldNotBeNull();
                     action.ProcessedOn.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Reporting/Reports/ReportsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Reporting/Reports/ReportsIntegrationTest.cs
@@ -26,18 +26,18 @@ namespace Checkout.Reports
             var reports = await DefaultApi.ReportsClient().GetAllReports(_query);
             
             reports.ShouldNotBeNull();
-            if (!reports.Data.IsNullOrEmpty())
+            if (reports.Data?.Count > 0)
             {
                 foreach (var report in reports.Data)
                 {
                     report.Id.ShouldNotBeNull();
                     report.CreatedOn.ShouldNotBeNull();
-                    report.Type.ShouldNotBeNull();
+                    report.Type.ShouldNotBe(default);
                     report.Account.ShouldNotBeNull();
                     report.Account.ClientId.ShouldNotBeNull();
                     report.Account.EntityId.ShouldNotBeNull();
-                    report.From.ShouldNotBeNull();
-                    report.To.ShouldNotBeNull();
+                    report.From.ShouldNotBe(default);
+                    report.To.ShouldNotBe(default);
                     report.Files.ShouldNotBeNull();
                 }
             }
@@ -49,7 +49,7 @@ namespace Checkout.Reports
             var reports = await DefaultApi.ReportsClient().GetAllReports(_query);
             
             reports.ShouldNotBeNull();
-            if (!reports.Data.IsNullOrEmpty())
+            if (reports.Data?.Count > 0)
             {
                 var reportDetails = reports.Data[0];
                 var detailsResponse = await DefaultApi.ReportsClient().GetReportDetails(reportDetails.Id);
@@ -64,7 +64,7 @@ namespace Checkout.Reports
             var reports = await DefaultApi.ReportsClient().GetAllReports(_query);
             
             reports.ShouldNotBeNull();
-            if (!reports.Data.IsNullOrEmpty())
+            if (reports.Data?.Count > 0)
             {
                 var reportDetails = reports.Data[0];
                 var detailsResponse = await DefaultApi.ReportsClient().GetReportDetails(reportDetails.Id);

--- a/test/CheckoutSdkTest/StandaloneAccountUpdater/StandaloneAccountUpdaterIntegrationTest.cs
+++ b/test/CheckoutSdkTest/StandaloneAccountUpdater/StandaloneAccountUpdaterIntegrationTest.cs
@@ -64,7 +64,11 @@ namespace Checkout.StandaloneAccountUpdater
 
             // Account updater returns 422 for standard test cards - likely requires cards that exist in the system
             // or specific card numbers that simulate real account updater scenarios
+#if NETSTANDARD2_0
+            exception.HttpStatusCode.ShouldBe((System.Net.HttpStatusCode)422);
+#else
             exception.HttpStatusCode.ShouldBe(System.Net.HttpStatusCode.UnprocessableEntity);
+#endif
         }
 
         // Common methods
@@ -131,14 +135,14 @@ namespace Checkout.StandaloneAccountUpdater
         private static void ValidateGetUpdatedCardCredentialsResponse(GetUpdatedCardCredentialsResponse response)
         {
             response.ShouldNotBeNull();
-            response.AccountUpdateStatus.ShouldNotBeNull();
+            response.AccountUpdateStatus.ShouldNotBe(default);
             
             if (response.AccountUpdateStatus == AccountUpdateStatus.CardUpdated || 
                 response.AccountUpdateStatus == AccountUpdateStatus.CardExpiryUpdated)
             {
                 response.Card.ShouldNotBeNull();
-                response.Card.ExpiryMonth.ShouldNotBeNull();
-                response.Card.ExpiryYear.ShouldNotBeNull();
+                response.Card.ExpiryMonth.ShouldNotBe(0);
+                response.Card.ExpiryYear.ShouldNotBe(0);
             }
             
             if (response.AccountUpdateStatus == AccountUpdateStatus.UpdateFailed)

--- a/test/CheckoutSdkTest/Transfers/TransfersIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Transfers/TransfersIntegrationTest.cs
@@ -30,14 +30,14 @@ namespace Checkout.Transfers
 
             createTransferResponse.ShouldNotBeNull();
             createTransferResponse.Id.ShouldNotBeNullOrEmpty();
-            createTransferResponse.Status.ShouldNotBeNull();
+            createTransferResponse.Status.ShouldNotBe(default);
             createTransferResponse.Links.ShouldNotBeNull();
             createTransferResponse.Links.ShouldNotBeEmpty();
 
             var transferDetailsResponse = await DefaultApi.TransfersClient().RetrieveATransfer(createTransferResponse.Id);
             transferDetailsResponse.ShouldNotBeNull();
-            transferDetailsResponse.Status.ShouldNotBeNull();
-            transferDetailsResponse.TransferType.ShouldNotBeNull();
+            transferDetailsResponse.Status.ShouldNotBe(default);
+            transferDetailsResponse.TransferType.ShouldNotBe(default);
             transferDetailsResponse.RequestedOn.ShouldNotBeNull();
             transferDetailsResponse.Source.ShouldNotBeNull();
             transferDetailsResponse.Source.EntityId.ShouldNotBeNull();
@@ -65,7 +65,7 @@ namespace Checkout.Transfers
 
             createTransferResponse.ShouldNotBeNull();
             createTransferResponse.Id.ShouldNotBeNullOrEmpty();
-            createTransferResponse.Status.ShouldNotBeNull();
+            createTransferResponse.Status.ShouldNotBe(default);
             createTransferResponse.Links.ShouldNotBeNull();
             createTransferResponse.Links.ShouldNotBeEmpty();
 

--- a/test/CheckoutSdkTest/Webhooks/Previous/WebhooksIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Webhooks/Previous/WebhooksIntegrationTest.cs
@@ -23,7 +23,7 @@ namespace Checkout.Webhooks.Previous
             var webhookResponses = await PreviousApi.WebhooksClient().RetrieveWebhooks();
             webhookResponses.HttpStatusCode.ShouldNotBeNull();
             webhookResponses.HttpStatusCode.ShouldNotBeNull();
-            if (!webhookResponses.Items.IsNullOrEmpty())
+            if (webhookResponses.Items?.Count > 0)
             {
                 foreach (var webhook in webhookResponses.Items)
                 {

--- a/test/CheckoutSdkTest/Workflows/WorkflowsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Workflows/WorkflowsIntegrationTest.cs
@@ -135,7 +135,7 @@ namespace Checkout.Workflows
 
             WorkflowActionResponse action = getWorkflowResponseUpdated.Actions[0];
             action.Id.ShouldNotBeNullOrEmpty();
-            action.Type.ShouldNotBeNull();
+            action.Type.ShouldNotBe(default);
         }
 
         [Fact(Skip = "unstable")]
@@ -208,7 +208,7 @@ namespace Checkout.Workflows
 
             updatedEventConditionResponse.ShouldNotBeNull();
             updatedEventConditionResponse.Id.ShouldNotBeNull();
-            updatedEventConditionResponse.Type.ShouldNotBeNull();
+            updatedEventConditionResponse.Type.ShouldNotBe(default);
         }
 
         [Fact(Skip = "unstable")]


### PR DESCRIPTION
This pull request introduces .NET 8 support across the SDK, updates related dependencies and build/test workflows, and makes a breaking change to the Agentic Commerce API by renaming a key method. It also includes minor test improvements and some conditional compilation cleanup.

**.NET 8 Support and Build/Dependency Updates**

* Added .NET 8 (`net8.0`) as a target framework to both `CheckoutSdk` and `CheckoutSdk.Extensions` projects, and updated their dependencies to include .NET 8 compatible packages. (`src/CheckoutSdk/CheckoutSdk.csproj`, `src/CheckoutSdk.Extensions/CheckoutSdk.Extensions.csproj`) [[1]](diffhunk://#diff-4418a66c744c1c0d92c03b58c0a07d33bc99409b0fb06a75dc9c816be87643a4L19-R27) [[2]](diffhunk://#diff-4418a66c744c1c0d92c03b58c0a07d33bc99409b0fb06a75dc9c816be87643a4R46-R49) [[3]](diffhunk://#diff-ebcf3ae1b128cf082c6de25cb7ba989544b83da35702edd8de7d6d617f962a87L16-R16) [[4]](diffhunk://#diff-ebcf3ae1b128cf082c6de25cb7ba989544b83da35702edd8de7d6d617f962a87R35-R40)
* Updated `global.json` to use .NET SDK version 8.0.420.
* Updated all GitHub Actions workflows to include .NET 8 in their build and test matrices. (`.github/workflows/build-master.yml`, `.github/workflows/build-pull-request.yml`, `.github/workflows/build-release.yml`, `.github/workflows/codeql-analysis.yml`) [[1]](diffhunk://#diff-53f6a76fa86b1994f9da743d84e130a48058a0d0657949c412c203d5f0aedfe8L14-R23) [[2]](diffhunk://#diff-53f6a76fa86b1994f9da743d84e130a48058a0d0657949c412c203d5f0aedfe8R40) [[3]](diffhunk://#diff-104c03339b92a1f7faaf8f4d9cb603bdf4765f6f6281cee6ece6cab1331aee30L13-R22) [[4]](diffhunk://#diff-104c03339b92a1f7faaf8f4d9cb603bdf4765f6f6281cee6ece6cab1331aee30R39) [[5]](diffhunk://#diff-4d14704b6b88fb06db888f96c03a8e9b3a5e07a4ee566d97d4111b2c05210e84L14-R22) [[6]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R45-R56)

**Conditional Compilation and Logging**

* Updated preprocessor directives throughout the codebase to use `NET5_0_OR_GREATER || NETSTANDARD2_0` instead of legacy combinations, ensuring correct logging and dependency usage for .NET 8 and simplifying multi-targeting logic. (`src/CheckoutSdk/AbstractCheckoutSdkBuilder.cs`, `src/CheckoutSdk/ApiClient.cs`, `src/CheckoutSdk/LogProvider.cs`, `src/CheckoutSdk/OAuthSdkCredentials.cs`) [[1]](diffhunk://#diff-7fa5dbd7c1d089fdba08fae3d5184c4f6df5dbca8270a77d6862ec64bf10743dL3-R3) [[2]](diffhunk://#diff-7fa5dbd7c1d089fdba08fae3d5184c4f6df5dbca8270a77d6862ec64bf10743dL35-R35) [[3]](diffhunk://#diff-9af2e0a12ca85931df9a277f560480e102e8927d7882bca65b735e0cc292aea9L1-R1) [[4]](diffhunk://#diff-9af2e0a12ca85931df9a277f560480e102e8927d7882bca65b735e0cc292aea9L21-R21) [[5]](diffhunk://#diff-9af2e0a12ca85931df9a277f560480e102e8927d7882bca65b735e0cc292aea9L219-R219) [[6]](diffhunk://#diff-9af2e0a12ca85931df9a277f560480e102e8927d7882bca65b735e0cc292aea9L296-R296) [[7]](diffhunk://#diff-a8f569669b512ff63362a2bc228a71ca3a631ff106cbcdf492a1c0d1cb333317L1-R1) [[8]](diffhunk://#diff-2378b6ada71e2cfe0495e4d3f39c5cd0a8244f0e7b278a44cddd3981c73c57a9L1-R1) [[9]](diffhunk://#diff-2378b6ada71e2cfe0495e4d3f39c5cd0a8244f0e7b278a44cddd3981c73c57a9L13-R13) [[10]](diffhunk://#diff-2378b6ada71e2cfe0495e4d3f39c5cd0a8244f0e7b278a44cddd3981c73c57a9L74-R74)

**Agentic Commerce API Breaking Change**

* Renamed the method `CreateDelegatedPayment` to `CreateDelegatedPaymentToken` in both `AgenticCommerceClient` and `IAgenticCommerceClient`, and updated all related tests and usages accordingly. [[1]](diffhunk://#diff-6b7d6d0df50d264b13e4bd66bce2f7fd41ed7a12eb2c4c9e4890e40f9daf7fe9L17-R17) [[2]](diffhunk://#diff-df8b166a9bb21a0aaae58b5a2bb66d8f4f4bd991914a82dcb314d59a91c46998L22-R22) [[3]](diffhunk://#diff-a9526f892814e40be99613c021380333c49454d16e59990f49106dedeaffbdedL54-R54) [[4]](diffhunk://#diff-a9526f892814e40be99613c021380333c49454d16e59990f49106dedeaffbdedL66-R66) [[5]](diffhunk://#diff-a9526f892814e40be99613c021380333c49454d16e59990f49106dedeaffbdedL75-R75) [[6]](diffhunk://#diff-a9526f892814e40be99613c021380333c49454d16e59990f49106dedeaffbdedL97-R97) [[7]](diffhunk://#diff-d9ce3a78431c7b974e683e68cb5be639efbcd8533b5e488e34540b35a6ea858bL53-R57)

**Test Improvements**

* Updated integration tests to use `.ShouldNotBe(default)` instead of `.ShouldNotBeNull()` for value types, improving the accuracy of assertions. (`test/CheckoutSdkTest/Accounts/AccountsIntegrationTest.cs`, `test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceIntegrationTest.cs`) [[1]](diffhunk://#diff-aaa0f12639a7ccca8f38c4b266be3a883fcc0cb3e080d54185eb0046634cd27aL441-R443) [[2]](diffhunk://#diff-aaa0f12639a7ccca8f38c4b266be3a883fcc0cb3e080d54185eb0046634cd27aL509-R511) [[3]](diffhunk://#diff-aaa0f12639a7ccca8f38c4b266be3a883fcc0cb3e080d54185eb0046634cd27aL685-R685) [[4]](diffhunk://#diff-d9ce3a78431c7b974e683e68cb5be639efbcd8533b5e488e34540b35a6ea858bL53-R57)

**Package Reference Conditions**

* Improved conditional package references for legacy frameworks in `CheckoutSdk.csproj` to avoid unnecessary dependencies for newer targets.

These updates ensure the SDK is compatible with the latest .NET ecosystem, improve CI reliability, and clarify API usage for Agentic Commerce.