### PR TITLE
fix: use string for CountryCode in phone models (closes #549)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>5.0.0</Version>
+        <Version>5.1.0</Version>
     </PropertyGroup>
 </Project>

--- a/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/HomePhone/HomePhone.cs
+++ b/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/HomePhone/HomePhone.cs
@@ -1,5 +1,3 @@
-using Checkout.Common;
-
 namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessionRequest.Source.Common.HomePhone
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessi
         /// [ 1 .. 3 ] characters
         /// ^\d{1,3}$
         /// </summary>
-        public CountryCode? CountryCode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// The rest of the number. According to ITU-E.164

--- a/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/MobilePhone/MobilePhone.cs
+++ b/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/MobilePhone/MobilePhone.cs
@@ -1,5 +1,3 @@
-using Checkout.Common;
-
 namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessionRequest.Source.Common.MobilePhone
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessi
         /// [ 1 .. 3 ] characters
         /// ^\d{1,3}$
         /// </summary>
-        public CountryCode? CountryCode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// The rest of the number. According to ITU-E.164

--- a/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/WorkPhone/WorkPhone.cs
+++ b/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/WorkPhone/WorkPhone.cs
@@ -1,5 +1,3 @@
-using Checkout.Common;
-
 namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessionRequest.Source.Common.WorkPhone
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessi
         /// [ 1 .. 3 ] characters
         /// ^\d{1,3}$
         /// </summary>
-        public CountryCode? CountryCode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// The rest of the number. According to ITU-E.164

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/Common/Source/CardSource/Phone/Phone.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/Common/Source/CardSource/Phone/Phone.cs
@@ -1,5 +1,3 @@
-using Checkout.Common;
-
 namespace Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.CardSource.Phone
 {
     /// <summary>
@@ -13,7 +11,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.CardSource.Ph
         /// [Optional]
         /// [ 1 .. 7 ] characters
         /// </summary>
-        public CountryCode? CountryCode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// The phone number. Required if source.type is tamara.

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/Common/Source/PaymentGetResponseKlarnaSourceSource/AccountHolder/Phone/Phone.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/Common/Source/PaymentGetResponseKlarnaSourceSource/AccountHolder/Phone/Phone.cs
@@ -1,5 +1,3 @@
-using Checkout.Common;
-
 namespace Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.PaymentGetResponseKlarnaSourceSource.AccountHolder.Phone
 {
     /// <summary>
@@ -9,9 +7,10 @@ namespace Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.PaymentGetRes
     public class Phone
     {
         /// <summary>
+        /// The international country calling code.
         /// [Optional]
         /// </summary>
-        public CountryCode? CountryCode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// [Optional]

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/POSTPayments/Requests/UnreferencedRefundRequest/Destination/Common/AccountHolder/Common/Phone/Phone.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/POSTPayments/Requests/UnreferencedRefundRequest/Destination/Common/AccountHolder/Common/Phone/Phone.cs
@@ -1,5 +1,3 @@
-using Checkout.Common;
-
 namespace Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Requests.UnreferencedRefundRequest.Destination.Common.
     AccountHolder.Common.Phone
 {
@@ -14,7 +12,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Requests.Unref
         /// [Required]
         /// [ 1 .. 7 ] characters
         /// </summary>
-        public CountryCode? CountryCode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// The digits of the phone number, not including the country_code.

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/POSTPayments/Responses/RequestAPaymentOrPayoutResponseCreated/Customer/Phone/Phone.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/POSTPayments/Responses/RequestAPaymentOrPayoutResponseCreated/Customer/Phone/Phone.cs
@@ -1,5 +1,3 @@
-using Checkout.Common;
-
 namespace Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Responses.RequestAPaymentOrPayoutResponseCreated.
     Customer.
     Phone
@@ -15,7 +13,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Responses.Requ
         /// [Optional]
         /// [ 1 .. 7 ] characters
         /// </summary>
-        public CountryCode? CountryCode { get; set; }
+        public string CountryCode { get; set; }
 
         /// <summary>
         /// The phone number. Required if source.type is tamara.

--- a/test/CheckoutSdkTest/Authentification/Standalone/SessionPhoneSerializationTest.cs
+++ b/test/CheckoutSdkTest/Authentification/Standalone/SessionPhoneSerializationTest.cs
@@ -1,0 +1,128 @@
+using Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessionRequest.Source.Common.HomePhone;
+using Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessionRequest.Source.Common.MobilePhone;
+using Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessionRequest.Source.Common.WorkPhone;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.Authentification.Standalone
+{
+    public class SessionPhoneSerializationTest
+    {
+        [Fact]
+        public void ShouldSerializeHomePhoneWithAllProperties()
+        {
+            var phone = new HomePhone { CountryCode = "44", Number = "2079460000" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldRoundTripHomePhone()
+        {
+            var original = new HomePhone { CountryCode = "44", Number = "2079460000" };
+            var serializer = new JsonSerializer();
+
+            var json = serializer.Serialize(original);
+            var deserialized = (HomePhone)serializer.Deserialize(json, typeof(HomePhone));
+
+            deserialized.CountryCode.ShouldBe("44");
+            deserialized.Number.ShouldBe("2079460000");
+        }
+
+        /// <summary>
+        /// Regression test for GitHub issue #549 — CountryCode enum serialised as ISO country code (e.g. "GB"),
+        /// causing country_code_invalid when the API expects a numeric ITU-E.164 dialing code (e.g. "44").
+        /// </summary>
+        [Fact]
+        public void Issue549_HomePhone_CountryCodeShouldSerializeAsNumericDialingCode()
+        {
+            var phone = new HomePhone { CountryCode = "44", Number = "2079460000" };
+
+            var json = new JsonSerializer().Serialize(phone);
+
+            json.ShouldContain("\"country_code\":\"44\"");
+            json.ShouldNotContain("\"country_code\":\"GB\"");
+        }
+
+        [Fact]
+        public void ShouldDeserializeHomePhoneFromSwaggerExample()
+        {
+            const string json = @"{""country_code"":""234"",""number"":""0204567895""}";
+
+            var phone = (HomePhone)new JsonSerializer().Deserialize(json, typeof(HomePhone));
+
+            phone.CountryCode.ShouldBe("234");
+            phone.Number.ShouldBe("0204567895");
+        }
+
+        [Fact]
+        public void ShouldSerializeMobilePhoneWithAllProperties()
+        {
+            var phone = new MobilePhone { CountryCode = "1", Number = "4155552671" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldRoundTripMobilePhone()
+        {
+            var original = new MobilePhone { CountryCode = "1", Number = "4155552671" };
+            var serializer = new JsonSerializer();
+
+            var json = serializer.Serialize(original);
+            var deserialized = (MobilePhone)serializer.Deserialize(json, typeof(MobilePhone));
+
+            deserialized.CountryCode.ShouldBe("1");
+            deserialized.Number.ShouldBe("4155552671");
+        }
+
+        /// <summary>
+        /// Regression test for GitHub issue #549.
+        /// </summary>
+        [Fact]
+        public void Issue549_MobilePhone_CountryCodeShouldSerializeAsNumericDialingCode()
+        {
+            var phone = new MobilePhone { CountryCode = "1", Number = "4155552671" };
+
+            var json = new JsonSerializer().Serialize(phone);
+
+            json.ShouldContain("\"country_code\":\"1\"");
+            json.ShouldNotContain("\"country_code\":\"US\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeWorkPhoneWithAllProperties()
+        {
+            var phone = new WorkPhone { CountryCode = "49", Number = "3012345678" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldRoundTripWorkPhone()
+        {
+            var original = new WorkPhone { CountryCode = "49", Number = "3012345678" };
+            var serializer = new JsonSerializer();
+
+            var json = serializer.Serialize(original);
+            var deserialized = (WorkPhone)serializer.Deserialize(json, typeof(WorkPhone));
+
+            deserialized.CountryCode.ShouldBe("49");
+            deserialized.Number.ShouldBe("3012345678");
+        }
+
+        /// <summary>
+        /// Regression test for GitHub issue #549.
+        /// </summary>
+        [Fact]
+        public void Issue549_WorkPhone_CountryCodeShouldSerializeAsNumericDialingCode()
+        {
+            var phone = new WorkPhone { CountryCode = "49", Number = "3012345678" };
+
+            var json = new JsonSerializer().Serialize(phone);
+
+            json.ShouldContain("\"country_code\":\"49\"");
+            json.ShouldNotContain("\"country_code\":\"DE\"");
+        }
+    }
+}

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/Common/Source/CardSourcePhoneSerializationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/Common/Source/CardSourcePhoneSerializationTest.cs
@@ -1,0 +1,49 @@
+using Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.CardSource.Phone;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.HandlePaymentsAndPayouts.Payments.Common.Source
+{
+    public class CardSourcePhoneSerializationTest
+    {
+        [Fact]
+        public void ShouldSerializeWithAllProperties()
+        {
+            var phone = new Phone { CountryCode = "+1", Number = "415 555 2671" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldSerializeWithRequiredPropertiesOnly()
+        {
+            var phone = new Phone { Number = "415 555 2671" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldRoundTripSerialize()
+        {
+            var original = new Phone { CountryCode = "+44", Number = "207 946 0000" };
+            var serializer = new JsonSerializer();
+
+            var json = serializer.Serialize(original);
+            var deserialized = (Phone)serializer.Deserialize(json, typeof(Phone));
+
+            deserialized.CountryCode.ShouldBe("+44");
+            deserialized.Number.ShouldBe("207 946 0000");
+        }
+
+        [Fact]
+        public void ShouldDeserializeFromSwaggerExample()
+        {
+            const string json = @"{""country_code"":""+1"",""number"":""415 555 2671""}";
+
+            var phone = (Phone)new JsonSerializer().Deserialize(json, typeof(Phone));
+
+            phone.CountryCode.ShouldBe("+1");
+            phone.Number.ShouldBe("415 555 2671");
+        }
+    }
+}

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/Common/Source/KlarnaSourceAccountHolderPhoneSerializationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/Common/Source/KlarnaSourceAccountHolderPhoneSerializationTest.cs
@@ -1,0 +1,49 @@
+using Checkout.HandlePaymentsAndPayouts.Payments.Common.Source.PaymentGetResponseKlarnaSourceSource.AccountHolder.Phone;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.HandlePaymentsAndPayouts.Payments.Common.Source
+{
+    public class KlarnaSourceAccountHolderPhoneSerializationTest
+    {
+        [Fact]
+        public void ShouldSerializeWithAllProperties()
+        {
+            var phone = new Phone { CountryCode = "+46", Number = "701234567" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldSerializeWithNoOptionalProperties()
+        {
+            var phone = new Phone();
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldRoundTripSerialize()
+        {
+            var original = new Phone { CountryCode = "+46", Number = "701234567" };
+            var serializer = new JsonSerializer();
+
+            var json = serializer.Serialize(original);
+            var deserialized = (Phone)serializer.Deserialize(json, typeof(Phone));
+
+            deserialized.CountryCode.ShouldBe("+46");
+            deserialized.Number.ShouldBe("701234567");
+        }
+
+        [Fact]
+        public void ShouldDeserializeFromSwaggerExample()
+        {
+            const string json = @"{""country_code"":""+1"",""number"":""415 555 2671""}";
+
+            var phone = (Phone)new JsonSerializer().Deserialize(json, typeof(Phone));
+
+            phone.CountryCode.ShouldBe("+1");
+            phone.Number.ShouldBe("415 555 2671");
+        }
+    }
+}

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/Requests/UnreferencedRefundRequest/AccountHolderPhoneSerializationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/Requests/UnreferencedRefundRequest/AccountHolderPhoneSerializationTest.cs
@@ -1,0 +1,49 @@
+using Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Requests.UnreferencedRefundRequest.Destination.Common.AccountHolder.Common.Phone;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Requests.UnreferencedRefundRequest
+{
+    public class AccountHolderPhoneSerializationTest
+    {
+        [Fact]
+        public void ShouldSerializeWithAllProperties()
+        {
+            var phone = new Phone { CountryCode = "+44", Number = "207 946 0000" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldSerializeWithRequiredPropertiesOnly()
+        {
+            var phone = new Phone { CountryCode = "+44", Number = "207 946 0000" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldRoundTripSerialize()
+        {
+            var original = new Phone { CountryCode = "+44", Number = "207 946 0000" };
+            var serializer = new JsonSerializer();
+
+            var json = serializer.Serialize(original);
+            var deserialized = (Phone)serializer.Deserialize(json, typeof(Phone));
+
+            deserialized.CountryCode.ShouldBe("+44");
+            deserialized.Number.ShouldBe("207 946 0000");
+        }
+
+        [Fact]
+        public void ShouldDeserializeFromSwaggerExample()
+        {
+            const string json = @"{""country_code"":""+1"",""number"":""415 555 2671""}";
+
+            var phone = (Phone)new JsonSerializer().Deserialize(json, typeof(Phone));
+
+            phone.CountryCode.ShouldBe("+1");
+            phone.Number.ShouldBe("415 555 2671");
+        }
+    }
+}

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/Responses/RequestAPaymentOrPayoutResponseCreated/CustomerPhoneSerializationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/Responses/RequestAPaymentOrPayoutResponseCreated/CustomerPhoneSerializationTest.cs
@@ -1,0 +1,49 @@
+using Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Responses.RequestAPaymentOrPayoutResponseCreated.Customer.Phone;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.HandlePaymentsAndPayouts.Payments.POSTPayments.Responses.RequestAPaymentOrPayoutResponseCreated
+{
+    public class CustomerPhoneSerializationTest
+    {
+        [Fact]
+        public void ShouldSerializeWithAllProperties()
+        {
+            var phone = new Phone { CountryCode = "+1", Number = "415 555 2671" };
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldSerializeWithNoOptionalProperties()
+        {
+            var phone = new Phone();
+
+            Should.NotThrow(() => new JsonSerializer().Serialize(phone));
+        }
+
+        [Fact]
+        public void ShouldRoundTripSerialize()
+        {
+            var original = new Phone { CountryCode = "+44", Number = "207 946 0000" };
+            var serializer = new JsonSerializer();
+
+            var json = serializer.Serialize(original);
+            var deserialized = (Phone)serializer.Deserialize(json, typeof(Phone));
+
+            deserialized.CountryCode.ShouldBe("+44");
+            deserialized.Number.ShouldBe("207 946 0000");
+        }
+
+        [Fact]
+        public void ShouldDeserializeFromSwaggerExample()
+        {
+            const string json = @"{""country_code"":""+1"",""number"":""415 555 2671""}";
+
+            var phone = (Phone)new JsonSerializer().Deserialize(json, typeof(Phone));
+
+            phone.CountryCode.ShouldBe("+1");
+            phone.Number.ShouldBe("415 555 2671");
+        }
+    }
+}


### PR DESCRIPTION
## What

Seven phone model classes used the `CountryCode` enum (ISO 3166-1 alpha-2, e.g. `"GB"`) for the `country_code` field. The API expects a numeric ITU-E.164 dialing code (1–3 digits, e.g. `"44"`), so the SDK was sending an invalid value and the API rejected requests with `country_code_invalid`.

## Changes

- `src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/HomePhone/HomePhone.cs` — `CountryCode?` enum → `string`, removed unused import
- `src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/MobilePhone/MobilePhone.cs` — same
- `src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/Source/Common/WorkPhone/WorkPhone.cs` — same
- `src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/Common/Source/CardSource/Phone/Phone.cs` — same
- `src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/Common/Source/PaymentGetResponseKlarnaSourceSource/AccountHolder/Phone/Phone.cs` — same
- `src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/POSTPayments/Responses/RequestAPaymentOrPayoutResponseCreated/Customer/Phone/Phone.cs` — same
- `src/CheckoutSdk/HandlePaymentsAndPayouts/Payments/POSTPayments/Requests/UnreferencedRefundRequest/Destination/Common/AccountHolder/Common/Phone/Phone.cs` — same
- `test/CheckoutSdkTest/Authentification/Standalone/SessionPhoneSerializationTest.cs` — new serialization tests for HomePhone, MobilePhone, WorkPhone (includes regression tests named after #549)
- `test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/Common/Source/CardSourcePhoneSerializationTest.cs` — new
- `test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/Common/Source/KlarnaSourceAccountHolderPhoneSerializationTest.cs` — new
- `test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/Responses/RequestAPaymentOrPayoutResponseCreated/CustomerPhoneSerializationTest.cs` — new
- `test/CheckoutSdkTest/HandlePaymentsAndPayouts/Payments/POSTPayments/Requests/UnreferencedRefundRequest/AccountHolderPhoneSerializationTest.cs` — new

## Root cause

The swagger `SessionPhone`, `PhoneNumber`, and related phone schemas define `country_code` as `type: string` (ITU-E.164 dialing code). The generated SDK classes incorrectly used the `CountryCode` enum, which encodes ISO 3166-1 alpha-2 country codes — a completely different concept sharing the same property name.

## Testing

- [x] All existing tests pass
- [x] 26 new serialization tests added across all 7 modified classes
- [x] Regression tests assert numeric dialing code serialises correctly and ISO code does not appear
- [x] No orphaned imports

## Related

Closes #549