### PR TITLE
IdempotencyKey to CreateDelegatedPaymentToken + some fixes

### DIFF
--- a/src/CheckoutSdk/Accounts/AccountsFilePurpose.cs
+++ b/src/CheckoutSdk/Accounts/AccountsFilePurpose.cs
@@ -22,7 +22,7 @@ namespace Checkout.Accounts
         [EnumMember(Value = "identification")]
         Identification,
         
-         [EnumMember(Value = "identity_verification")]
+        [EnumMember(Value = "identity_verification")]
         IdentityVerification,
         
         [EnumMember(Value = "dispute_evidence")]

--- a/src/CheckoutSdk/AgenticCommerce/AgenticCommerceClient.cs
+++ b/src/CheckoutSdk/AgenticCommerce/AgenticCommerceClient.cs
@@ -16,6 +16,7 @@ namespace Checkout.AgenticCommerce
 
         public Task<DelegatedPaymentResponse> CreateDelegatedPaymentToken(DelegatedPaymentRequest request,
             DelegatedPaymentHeaders headers,
+            string idempotencyKey = null,
             CancellationToken cancellationToken = default)
         {
             CheckoutUtils.ValidateParams("request", request, "headers", headers);
@@ -24,7 +25,7 @@ namespace Checkout.AgenticCommerce
                 SdkAuthorization(),
                 request,
                 cancellationToken,
-                null,
+                idempotencyKey,
                 headers);
         }
     }

--- a/src/CheckoutSdk/AgenticCommerce/IAgenticCommerceClient.cs
+++ b/src/CheckoutSdk/AgenticCommerce/IAgenticCommerceClient.cs
@@ -21,6 +21,7 @@ namespace Checkout.AgenticCommerce
         /// <returns>The created delegated payment token</returns>
         Task<DelegatedPaymentResponse> CreateDelegatedPaymentToken(DelegatedPaymentRequest request,
             DelegatedPaymentHeaders headers,
+            string idempotencyKey = null,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/CheckoutSdk/AgenticCommerce/Requests/DelegatedPaymentAllowance.cs
+++ b/src/CheckoutSdk/AgenticCommerce/Requests/DelegatedPaymentAllowance.cs
@@ -1,4 +1,5 @@
 using Checkout.AgenticCommerce.Entities;
+using Checkout.Common;
 using System;
 
 namespace Checkout.AgenticCommerce.Requests
@@ -26,7 +27,7 @@ namespace Checkout.AgenticCommerce.Requests
         /// [Required]
         /// 3 characters.
         /// </summary>
-        public string Currency { get; set; }
+        public Currency Currency { get; set; }
 
         /// <summary>
         /// The unique identifier of the merchant that will process the payment.

--- a/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceClientTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceClientTest.cs
@@ -95,10 +95,34 @@ namespace Checkout.AgenticCommerce
                 .ReturnsAsync(expectedResponse);
 
             IAgenticCommerceClient client = new AgenticCommerceClient(_apiClient.Object, _configuration.Object);
-            var response = await client.CreateDelegatedPaymentToken(request, headers, cancellationToken);
+            var response = await client.CreateDelegatedPaymentToken(request, headers, cancellationToken: cancellationToken);
 
             response.ShouldNotBeNull();
             response.Id.ShouldBe("vt_test123");
+        }
+
+        [Fact]
+        public async Task CreateDelegatedPayment_WithIdempotencyKey_ShouldPassKeyToApiClient()
+        {
+            var request = CreateValidDelegatedPaymentRequest();
+            var headers = CreateValidDelegatedPaymentHeaders();
+            const string idempotencyKey = "test-idempotency-key-123";
+            var expectedResponse = new DelegatedPaymentResponse { Id = "vt_idempotent123" };
+
+            _apiClient.Setup(c => c.Post<DelegatedPaymentResponse>(
+                    "agentic_commerce/delegate_payment",
+                    _authorization,
+                    request,
+                    CancellationToken.None,
+                    idempotencyKey,
+                    headers))
+                .ReturnsAsync(expectedResponse);
+
+            IAgenticCommerceClient client = new AgenticCommerceClient(_apiClient.Object, _configuration.Object);
+            var response = await client.CreateDelegatedPaymentToken(request, headers, idempotencyKey);
+
+            response.ShouldNotBeNull();
+            response.Id.ShouldBe("vt_idempotent123");
         }
 
         private DelegatedPaymentRequest CreateValidDelegatedPaymentRequest()

--- a/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceClientTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceClientTest.cs
@@ -1,5 +1,6 @@
 using Checkout.Accounts;
 using Checkout.AgenticCommerce;
+using Checkout.Common;
 using Checkout.AgenticCommerce.Entities;
 using Checkout.AgenticCommerce.Requests;
 using Checkout.AgenticCommerce.Responses;
@@ -116,7 +117,7 @@ namespace Checkout.AgenticCommerce
                 {
                     Reason = DelegatedPaymentAllowanceReason.OneTime,
                     MaxAmount = 10000,
-                    Currency = "USD",
+                    Currency = Currency.USD,
                     MerchantId = "cli_vkuhvk4vjn2edkps7dfsq6emqm",
                     CheckoutSessionId = "1PQrsT",
                     ExpiresAt = DateTime.UtcNow.AddHours(1)

--- a/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceIntegrationTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceIntegrationTest.cs
@@ -58,5 +58,51 @@ namespace Checkout.AgenticCommerce
             response.Created.ShouldNotBe(default);
             response.Metadata.ShouldNotBeNull();
         }
+
+        [Fact(Skip = "Requires a valid HMAC signing key and merchant enabled for agentic commerce")]
+        public async Task CreateDelegatedPayment_WithIdempotencyKey_ShouldReturnToken()
+        {
+            var request = new DelegatedPaymentRequest
+            {
+                PaymentMethod = new DelegatedPaymentMethodCard
+                {
+                    CardNumberType = DelegatedCardNumberType.Fpan,
+                    Number = "4242424242424242",
+                    ExpMonth = "11",
+                    ExpYear = "2026",
+                    Metadata = new Dictionary<string, string> { { "issuing_bank", "test" } }
+                },
+                Allowance = new DelegatedPaymentAllowance
+                {
+                    Reason = DelegatedPaymentAllowanceReason.OneTime,
+                    MaxAmount = 10000,
+                    Currency = Currency.USD,
+                    MerchantId = "cli_vkuhvk4vjn2edkps7dfsq6emqm",
+                    CheckoutSessionId = "1PQrsT",
+                    ExpiresAt = DateTime.UtcNow.AddHours(1)
+                },
+                RiskSignals = new List<DelegatedPaymentRiskSignal>
+                {
+                    new DelegatedPaymentRiskSignal { Type = "card_testing", Score = 10, Action = "blocked" }
+                },
+                Metadata = new Dictionary<string, string> { { "campaign", "q4" } }
+            };
+
+            // Signature must be computed as: Base64(HMAC-SHA256(signingKey, Timestamp + RequestBody))
+            var headers = new DelegatedPaymentHeaders
+            {
+                Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+                Signature = "computed-hmac-sha256-base64-signature"
+            };
+
+            var idempotencyKey = Guid.NewGuid().ToString();
+            var response = await DefaultApi.AgenticCommerceClient()
+                .CreateDelegatedPaymentToken(request, headers, idempotencyKey);
+
+            response.ShouldNotBeNull();
+            response.Id.ShouldNotBeNullOrEmpty();
+            response.Created.ShouldNotBe(default);
+            response.Metadata.ShouldNotBeNull();
+        }
     }
 }

--- a/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceIntegrationTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/AgenticCommerceIntegrationTest.cs
@@ -1,5 +1,6 @@
 using Checkout.AgenticCommerce.Entities;
 using Checkout.AgenticCommerce.Requests;
+using Checkout.Common;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,7 @@ namespace Checkout.AgenticCommerce
                 {
                     Reason = DelegatedPaymentAllowanceReason.OneTime,
                     MaxAmount = 10000,
-                    Currency = "USD",
+                    Currency = Currency.USD,
                     MerchantId = "cli_vkuhvk4vjn2edkps7dfsq6emqm",
                     CheckoutSessionId = "1PQrsT",
                     ExpiresAt = DateTime.UtcNow.AddHours(1)

--- a/test/CheckoutSdkTest/AgenticCommerce/DelegatedPaymentRequestSerializationTest.cs
+++ b/test/CheckoutSdkTest/AgenticCommerce/DelegatedPaymentRequestSerializationTest.cs
@@ -25,7 +25,7 @@ namespace Checkout.AgenticCommerce
                 {
                     Reason = DelegatedPaymentAllowanceReason.OneTime,
                     MaxAmount = 10000,
-                    Currency = "USD",
+                    Currency = Currency.USD,
                     MerchantId = "cli_test",
                     CheckoutSessionId = "1PQrsT",
                     ExpiresAt = DateTime.UtcNow.AddHours(1)
@@ -67,7 +67,7 @@ namespace Checkout.AgenticCommerce
                 {
                     Reason = DelegatedPaymentAllowanceReason.OneTime,
                     MaxAmount = 10000,
-                    Currency = "USD",
+                    Currency = Currency.USD,
                     MerchantId = "cli_vkuhvk4vjn2edkps7dfsq6emqm",
                     CheckoutSessionId = "1PQrsT",
                     ExpiresAt = new DateTime(2025, 10, 9, 7, 20, 50)
@@ -107,7 +107,7 @@ namespace Checkout.AgenticCommerce
                 {
                     Reason = DelegatedPaymentAllowanceReason.OneTime,
                     MaxAmount = 5000,
-                    Currency = "GBP",
+                    Currency = Currency.GBP,
                     MerchantId = "cli_test",
                     CheckoutSessionId = "sess123",
                     ExpiresAt = new DateTime(2026, 1, 1)
@@ -120,7 +120,7 @@ namespace Checkout.AgenticCommerce
             var json = serializer.Serialize(original);
             var deserialized = (DelegatedPaymentRequest)serializer.Deserialize(json, typeof(DelegatedPaymentRequest));
 
-            deserialized.Allowance.Currency.ShouldBe("GBP");
+            deserialized.Allowance.Currency.ShouldBe(Currency.GBP);
             deserialized.Allowance.MaxAmount.ShouldBe(5000L);
             deserialized.PaymentMethod.Number.ShouldBe("4242424242424242");
             deserialized.Metadata["key"].ShouldBe("value");


### PR DESCRIPTION
This pull request introduces two main improvements to the Agentic Commerce SDK: it adds support for passing an optional idempotency key when creating a delegated payment token, and it refactors the `Currency` property in `DelegatedPaymentAllowance` to use the strongly-typed `Currency` enum instead of a string. The changes are reflected in both the implementation and the corresponding tests.

**API enhancements:**

* The `CreateDelegatedPaymentToken` method in both `AgenticCommerceClient` and `IAgenticCommerceClient` now accepts an optional `idempotencyKey` parameter, allowing clients to provide an idempotency key for safer and repeatable operations. [[1]](diffhunk://#diff-6b7d6d0df50d264b13e4bd66bce2f7fd41ed7a12eb2c4c9e4890e40f9daf7fe9R19) [[2]](diffhunk://#diff-6b7d6d0df50d264b13e4bd66bce2f7fd41ed7a12eb2c4c9e4890e40f9daf7fe9L27-R28) [[3]](diffhunk://#diff-df8b166a9bb21a0aaae58b5a2bb66d8f4f4bd991914a82dcb314d59a91c46998R24)

**Type safety improvements:**

* The `Currency` property in `DelegatedPaymentAllowance` is now of type `Currency` (enum) instead of a string, improving type safety and reducing the risk of invalid currency codes.

**Test updates:**

* All relevant tests have been updated to use the `Currency` enum instead of string values for the `Currency` property in delegated payment requests and assertions. [[1]](diffhunk://#diff-a9526f892814e40be99613c021380333c49454d16e59990f49106dedeaffbdedL119-R120) [[2]](diffhunk://#diff-d9ce3a78431c7b974e683e68cb5be639efbcd8533b5e488e34540b35a6ea858bL34-R35) [[3]](diffhunk://#diff-c6373ba73d39daf65cb2bddf7ea35f9548128bb2adaf3befb4e8ff9dc7a77eb8L28-R28) [[4]](diffhunk://#diff-c6373ba73d39daf65cb2bddf7ea35f9548128bb2adaf3befb4e8ff9dc7a77eb8L70-R70) [[5]](diffhunk://#diff-c6373ba73d39daf65cb2bddf7ea35f9548128bb2adaf3befb4e8ff9dc7a77eb8L110-R110) [[6]](diffhunk://#diff-c6373ba73d39daf65cb2bddf7ea35f9548128bb2adaf3befb4e8ff9dc7a77eb8L123-R123)
* Necessary using directives for `Checkout.Common` (where the `Currency` enum is defined) have been added to affected files. [[1]](diffhunk://#diff-804797e8978928b98f5095ceaf7e9f8df3b086380a372cbb2b9800aa633be798R2) [[2]](diffhunk://#diff-a9526f892814e40be99613c021380333c49454d16e59990f49106dedeaffbdedR3) [[3]](diffhunk://#diff-d9ce3a78431c7b974e683e68cb5be639efbcd8533b5e488e34540b35a6ea858bR3)- AgenticCommerce Currency field update