### PR TITLE
fix: tolerate unknown enum values during JSON deserialization

### DIFF
--- a/src/CheckoutSdk/JsonSerializer.cs
+++ b/src/CheckoutSdk/JsonSerializer.cs
@@ -53,6 +53,7 @@ namespace Checkout
                 ContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() },
                 Converters = new JsonConverter[]
                 {
+                    new CardTypeUnknownConverter(),
                     new StringEnumConverter(),
                     // Instruments CS2
                     new CreateInstrumentResponseTypeConverter(), 
@@ -95,6 +96,40 @@ namespace Checkout
             };
 
             return converter;
+        }
+
+        private class CardTypeUnknownConverter : StringEnumConverter
+        {
+            private static readonly HashSet<Type> CardTypeEnums = new HashSet<Type>
+            {
+                typeof(Common.CardType),
+                typeof(HandlePaymentsAndPayouts.Payments.Common.Source.CardSource.CardType),
+                typeof(Authentication.Standalone.Common.Responses.Card.Metadata.CardType),
+            };
+
+            public override bool CanConvert(Type objectType)
+            {
+                var underlying = Nullable.GetUnderlyingType(objectType) ?? objectType;
+                return CardTypeEnums.Contains(underlying);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+                Newtonsoft.Json.JsonSerializer serializer)
+            {
+                if (reader.TokenType == JsonToken.Null)
+                    return null;
+
+                try
+                {
+                    return base.ReadJson(reader, objectType, existingValue, serializer);
+                }
+                catch (JsonSerializationException) when (
+                    reader.TokenType == JsonToken.String &&
+                    !string.IsNullOrEmpty(reader.Value as string))
+                {
+                    return Nullable.GetUnderlyingType(objectType) != null ? null : existingValue;
+                }
+            }
         }
 
         private class ShortDateTimeConverter : JsonConverter

--- a/test/CheckoutSdkTest/JsonSerializerTest.cs
+++ b/test/CheckoutSdkTest/JsonSerializerTest.cs
@@ -1,6 +1,8 @@
 using Checkout.Accounts.Entities.Common.Company;
 using Checkout.Accounts.Entities.Response;
+using Checkout.Common;
 using Checkout.Financial;
+using Newtonsoft.Json;
 using Checkout.Issuing.Cards.Requests.Create;
 using Checkout.Issuing.Common;
 using Checkout.Issuing.Common.Responses;
@@ -279,16 +281,72 @@ namespace Checkout
             // This method tests the custom ShortDateTimeConverter
             var serializer = new JsonSerializer();
             var date = "{ \"datetime\" : \"2025-10-30\" }";
-            
+
             // Test deserialization
             DummyDateTime dummyDate = (DummyDateTime) serializer.Deserialize(date, typeof(DummyDateTime));
-            
+
             // Test serialization as well
             var serializedJson = serializer.Serialize(dummyDate);
-            
+
             Assert.NotNull(dummyDate);
             Assert.Equal(new DateTime(2025, 10, 30), dummyDate.Datetime);
             Assert.Contains("2025-10-30", serializedJson);
+        }
+
+        [Fact]
+        public void ShouldDeserializeKnownCardType()
+        {
+            const string json = @"{""type"":""card"",""card_type"":""Credit""}";
+            var source = (CardResponseSource)new JsonSerializer().Deserialize(json, typeof(CardResponseSource));
+            source.CardType.ShouldBe(CardType.Credit);
+        }
+
+        [Fact]
+        public void ShouldReturnNullForUnknownCardTypeEnumValue()
+        {
+            const string json = @"{""type"":""card"",""card_type"":""UNKNOWN""}";
+            var source = (CardResponseSource)new JsonSerializer().Deserialize(json, typeof(CardResponseSource));
+            source.ShouldNotBeNull();
+            source.CardType.ShouldBeNull();
+        }
+
+        [Fact]
+        public void ShouldDeserializeFullPaymentResponseWithUnknownCardType()
+        {
+            const string json = @"{
+                ""id"": ""pay_talabat_incident"",
+                ""status"": ""Authorized"",
+                ""approved"": true,
+                ""source"": {
+                    ""type"": ""card"",
+                    ""last4"": ""4242"",
+                    ""card_type"": ""UNKNOWN""
+                }
+            }";
+
+            PaymentResponse response = null;
+            Should.NotThrow(() =>
+                response = (PaymentResponse)new JsonSerializer().Deserialize(json, typeof(PaymentResponse)));
+            response.ShouldNotBeNull();
+            response.Approved.ShouldBe(true);
+            var source = response.Source.ShouldBeAssignableTo<CardResponseSource>();
+            source.CardType.ShouldBeNull();
+        }
+
+        [Fact]
+        public void ShouldThrowWhenCardTypeTokenIsNotAString()
+        {
+            const string json = @"{""type"":""card"",""card_type"":true}";
+            Should.Throw<JsonSerializationException>(() =>
+                new JsonSerializer().Deserialize(json, typeof(CardResponseSource)));
+        }
+
+        [Fact]
+        public void ShouldThrowForUnknownValueOnNonCardTypeEnum()
+        {
+            const string json = @"{""type"":""card"",""card_category"":""UNKNOWN""}";
+            Should.Throw<JsonSerializationException>(() =>
+                new JsonSerializer().Deserialize(json, typeof(CardResponseSource)));
         }
     }
 }


### PR DESCRIPTION
**Summary**
The SDK was throwing a `JsonSerializationException` when the API returned an unrecognised value for `card_type` (e.g. `UNKNOWN`). This caused the entire payment response deserialization to fail, turning a missing metadata field into a full payment failure for merchants.

The fix introduces `CardTypeUnknownConverter`, a converter scoped exclusively to the three `CardType` enums in the SDK. It returns `null` when an unrecognised string arrives, using a `when` filter to restrict tolerance to `JsonToken.String` only — wrong token types (e.g. booleans, objects) and all other enums continue to throw normally via the global `StringEnumConverter`.

**Changes**
- `src/CheckoutSdk/JsonSerializer.cs` — replaced broad `ToleratingStringEnumConverter` with `CardTypeUnknownConverter`, which overrides `CanConvert` to match only `Common.CardType`, `HandlePaymentsAndPayouts...CardType`, and `Authentication.Standalone...CardType`; catches `JsonSerializationException` only when `reader.TokenType == JsonToken.String` and the value is non-empty
- `test/CheckoutSdkTest/JsonSerializerTest.cs` — five new tests: known value deserializes correctly, `UNKNOWN` returns `null`, full `PaymentResponse` with `UNKNOWN` does not throw, wrong token type (`true`) still throws, unknown value on non-`CardType` enum (`card_category`) still throws

**API Reference**
- `GET /payments/{id}` — `source.card_type`
- `POST /payments` response — `source.card_type`

**Breaking changes**
None. Previously nullable `CardType?` fields that threw on unknown string values now return `null` — a safer and already-valid state. All other enum fields are unaffected.

**README**
No changes needed.