### PR TITLE
fix: route forward and identity clients to dedicated base URLs

### DIFF
--- a/src/CheckoutSdk/CheckoutApi.cs
+++ b/src/CheckoutSdk/CheckoutApi.cs
@@ -101,13 +101,13 @@ namespace Checkout
             _financialClient = new FinancialClient(baseApiClient, configuration);
             _issuingClient = new IssuingClient(baseApiClient, configuration);
             _paymentContextsClient = new PaymentContextsClient(baseApiClient, configuration);
-            _forwardClient = new ForwardClient(baseApiClient, configuration);
+            _forwardClient = new ForwardClient(ForwardApiClient(configuration), configuration);
             _flowClient = new FlowClient(baseApiClient, configuration);
-            _applicantsClient = new ApplicantsClient(baseApiClient, configuration);
-            _amlScreeningClient = new AmlScreeningClient(baseApiClient, configuration);
-            _faceAuthenticationClient = new FaceAuthenticationClient(baseApiClient, configuration);
-            _idDocumentVerificationClient = new IdDocumentVerificationClient(baseApiClient, configuration);
-            _identityVerificationClient = new IdentityVerificationClient(baseApiClient, configuration);
+            _applicantsClient = new ApplicantsClient(IdentityApiClient(configuration), configuration);
+            _amlScreeningClient = new AmlScreeningClient(IdentityApiClient(configuration), configuration);
+            _faceAuthenticationClient = new FaceAuthenticationClient(IdentityApiClient(configuration), configuration);
+            _idDocumentVerificationClient = new IdDocumentVerificationClient(IdentityApiClient(configuration), configuration);
+            _identityVerificationClient = new IdentityVerificationClient(IdentityApiClient(configuration), configuration);
             _networkTokensClient = new NetworkTokensClient(baseApiClient, configuration);
             _paymentSetupsClient = new PaymentSetupsClient(baseApiClient, configuration);
             _applePayClient = new ApplePayClient(baseApiClient, configuration);
@@ -146,6 +146,20 @@ namespace Checkout
         {
             return new ApiClient(configuration.HttpClientFactory,
                 configuration.Environment.GetAttribute<EnvironmentAttribute>().BalancesApiUri,
+                configuration.RecordTelemetry);
+        }
+
+        private static ApiClient ForwardApiClient(CheckoutConfiguration configuration)
+        {
+            return new ApiClient(configuration.HttpClientFactory,
+                configuration.Environment.GetAttribute<EnvironmentAttribute>().ForwardApiUri,
+                configuration.RecordTelemetry);
+        }
+
+        private static ApiClient IdentityApiClient(CheckoutConfiguration configuration)
+        {
+            return new ApiClient(configuration.HttpClientFactory,
+                configuration.Environment.GetAttribute<EnvironmentAttribute>().IdentityApiUri,
                 configuration.RecordTelemetry);
         }
 

--- a/src/CheckoutSdk/CheckoutApi.cs
+++ b/src/CheckoutSdk/CheckoutApi.cs
@@ -99,13 +99,13 @@ namespace Checkout
             _financialClient = new FinancialClient(baseApiClient, configuration);
             _issuingClient = new IssuingClient(baseApiClient, configuration);
             _paymentContextsClient = new PaymentContextsClient(baseApiClient, configuration);
-            _forwardClient = new ForwardClient(baseApiClient, configuration);
+            _forwardClient = new ForwardClient(ForwardApiClient(configuration), configuration);
             _flowClient = new FlowClient(baseApiClient, configuration);
-            _applicantsClient = new ApplicantsClient(baseApiClient, configuration);
-            _amlScreeningClient = new AmlScreeningClient(baseApiClient, configuration);
-            _faceAuthenticationClient = new FaceAuthenticationClient(baseApiClient, configuration);
-            _idDocumentVerificationClient = new IdDocumentVerificationClient(baseApiClient, configuration);
-            _identityVerificationClient = new IdentityVerificationClient(baseApiClient, configuration);
+            _applicantsClient = new ApplicantsClient(IdentityApiClient(configuration), configuration);
+            _amlScreeningClient = new AmlScreeningClient(IdentityApiClient(configuration), configuration);
+            _faceAuthenticationClient = new FaceAuthenticationClient(IdentityApiClient(configuration), configuration);
+            _idDocumentVerificationClient = new IdDocumentVerificationClient(IdentityApiClient(configuration), configuration);
+            _identityVerificationClient = new IdentityVerificationClient(IdentityApiClient(configuration), configuration);
             _networkTokensClient = new NetworkTokensClient(baseApiClient, configuration);
             _paymentSetupsClient = new PaymentSetupsClient(baseApiClient, configuration);
             _applePayClient = new ApplePayClient(baseApiClient, configuration);
@@ -143,6 +143,20 @@ namespace Checkout
         {
             return new ApiClient(configuration.HttpClientFactory,
                 configuration.Environment.GetAttribute<EnvironmentAttribute>().BalancesApiUri,
+                configuration.RecordTelemetry);
+        }
+
+        private static ApiClient ForwardApiClient(CheckoutConfiguration configuration)
+        {
+            return new ApiClient(configuration.HttpClientFactory,
+                configuration.Environment.GetAttribute<EnvironmentAttribute>().ForwardApiUri,
+                configuration.RecordTelemetry);
+        }
+
+        private static ApiClient IdentityApiClient(CheckoutConfiguration configuration)
+        {
+            return new ApiClient(configuration.HttpClientFactory,
+                configuration.Environment.GetAttribute<EnvironmentAttribute>().IdentityApiUri,
                 configuration.RecordTelemetry);
         }
 

--- a/src/CheckoutSdk/CheckoutApi.cs
+++ b/src/CheckoutSdk/CheckoutApi.cs
@@ -101,11 +101,12 @@ namespace Checkout
             _paymentContextsClient = new PaymentContextsClient(baseApiClient, configuration);
             _forwardClient = new ForwardClient(ForwardApiClient(configuration), configuration);
             _flowClient = new FlowClient(baseApiClient, configuration);
-            _applicantsClient = new ApplicantsClient(IdentityApiClient(configuration), configuration);
-            _amlScreeningClient = new AmlScreeningClient(IdentityApiClient(configuration), configuration);
-            _faceAuthenticationClient = new FaceAuthenticationClient(IdentityApiClient(configuration), configuration);
-            _idDocumentVerificationClient = new IdDocumentVerificationClient(IdentityApiClient(configuration), configuration);
-            _identityVerificationClient = new IdentityVerificationClient(IdentityApiClient(configuration), configuration);
+            var identityApiClient = IdentityApiClient(configuration);
+            _applicantsClient = new ApplicantsClient(identityApiClient, configuration);
+            _amlScreeningClient = new AmlScreeningClient(identityApiClient, configuration);
+            _faceAuthenticationClient = new FaceAuthenticationClient(identityApiClient, configuration);
+            _idDocumentVerificationClient = new IdDocumentVerificationClient(identityApiClient, configuration);
+            _identityVerificationClient = new IdentityVerificationClient(identityApiClient, configuration);
             _networkTokensClient = new NetworkTokensClient(baseApiClient, configuration);
             _paymentSetupsClient = new PaymentSetupsClient(baseApiClient, configuration);
             _applePayClient = new ApplePayClient(baseApiClient, configuration);

--- a/src/CheckoutSdk/CheckoutApi.cs
+++ b/src/CheckoutSdk/CheckoutApi.cs
@@ -103,11 +103,12 @@ namespace Checkout
             _paymentContextsClient = new PaymentContextsClient(baseApiClient, configuration);
             _forwardClient = new ForwardClient(ForwardApiClient(configuration), configuration);
             _flowClient = new FlowClient(baseApiClient, configuration);
-            _applicantsClient = new ApplicantsClient(IdentityApiClient(configuration), configuration);
-            _amlScreeningClient = new AmlScreeningClient(IdentityApiClient(configuration), configuration);
-            _faceAuthenticationClient = new FaceAuthenticationClient(IdentityApiClient(configuration), configuration);
-            _idDocumentVerificationClient = new IdDocumentVerificationClient(IdentityApiClient(configuration), configuration);
-            _identityVerificationClient = new IdentityVerificationClient(IdentityApiClient(configuration), configuration);
+            var identityApiClient = IdentityApiClient(configuration);
+            _applicantsClient = new ApplicantsClient(identityApiClient, configuration);
+            _amlScreeningClient = new AmlScreeningClient(identityApiClient, configuration);
+            _faceAuthenticationClient = new FaceAuthenticationClient(identityApiClient, configuration);
+            _idDocumentVerificationClient = new IdDocumentVerificationClient(identityApiClient, configuration);
+            _identityVerificationClient = new IdentityVerificationClient(identityApiClient, configuration);
             _networkTokensClient = new NetworkTokensClient(baseApiClient, configuration);
             _paymentSetupsClient = new PaymentSetupsClient(baseApiClient, configuration);
             _applePayClient = new ApplePayClient(baseApiClient, configuration);

--- a/src/CheckoutSdk/Environment.cs
+++ b/src/CheckoutSdk/Environment.cs
@@ -47,7 +47,7 @@ namespace Checkout
         {
             Uri newEnvironment = new Uri(originalUrl.ToString());
             
-            Regex regex = new Regex(@"^(?:pl-)?[a-z0-9]+$");
+            Regex regex = new Regex(@"^(?:pl-)?[a-z0-9]+$", RegexOptions.None, TimeSpan.FromMilliseconds(100));
             if (regex.IsMatch(subdomain))
             {
                 UriBuilder merchantUrl = new UriBuilder(originalUrl);

--- a/src/CheckoutSdk/Environment.cs
+++ b/src/CheckoutSdk/Environment.cs
@@ -47,7 +47,7 @@ namespace Checkout
         {
             Uri newEnvironment = new Uri(originalUrl.ToString());
             
-            Regex regex = new Regex(@"^[a-z0-9]+(-[a-z0-9]+)*$");
+            Regex regex = new Regex(@"^(?:pl-)?[a-z0-9]+$");
             if (regex.IsMatch(subdomain))
             {
                 UriBuilder merchantUrl = new UriBuilder(originalUrl);

--- a/src/CheckoutSdk/Environment.cs
+++ b/src/CheckoutSdk/Environment.cs
@@ -9,14 +9,18 @@ namespace Checkout
             "https://access.sandbox.checkout.com/connect/token",
             "https://files.sandbox.checkout.com/",
             "https://transfers.sandbox.checkout.com/",
-            "https://balances.sandbox.checkout.com/")]
+            "https://balances.sandbox.checkout.com/",
+            "https://forward.sandbox.checkout.com/",
+            "https://identity-verification.sandbox.checkout.com/")]
         Sandbox,
 
         [Environment("https://api.checkout.com/",
             "https://access.checkout.com/connect/token",
             "https://files.checkout.com/",
             "https://transfers.checkout.com/",
-            "https://balances.checkout.com/")]
+            "https://balances.checkout.com/",
+            "https://forward.checkout.com/",
+            "https://identity-verification.checkout.com/")]
         Production
     }
 
@@ -43,7 +47,7 @@ namespace Checkout
         {
             Uri newEnvironment = new Uri(originalUrl.ToString());
             
-            Regex regex = new Regex(@"^[0-9a-z]+$");
+            Regex regex = new Regex(@"^[a-z0-9]+(-[a-z0-9]+)*$");
             if (regex.IsMatch(subdomain))
             {
                 UriBuilder merchantUrl = new UriBuilder(originalUrl);

--- a/src/CheckoutSdk/EnvironmentAttribute.cs
+++ b/src/CheckoutSdk/EnvironmentAttribute.cs
@@ -8,21 +8,26 @@ namespace Checkout
         public Uri AuthorizationUri { get; }
         public Uri FilesApiUri { get; }
         public Uri TransfersApiUri { get; }
-
         public Uri BalancesApiUri { get; }
+        public Uri ForwardApiUri { get; }
+        public Uri IdentityApiUri { get; }
 
         public EnvironmentAttribute(
             string apiUri,
             string authorizationUri,
             string filesApiUri,
             string transfersApiUri,
-            string balancesApiUri)
+            string balancesApiUri,
+            string forwardApiUri,
+            string identityApiUri)
         {
             ApiUri = new Uri(apiUri);
             FilesApiUri = new Uri(filesApiUri);
             AuthorizationUri = new Uri(authorizationUri);
             TransfersApiUri = new Uri(transfersApiUri);
             BalancesApiUri = new Uri(balancesApiUri);
+            ForwardApiUri = new Uri(forwardApiUri);
+            IdentityApiUri = new Uri(identityApiUri);
         }
     }
 }

--- a/src/CheckoutSdk/OAuthScope.cs
+++ b/src/CheckoutSdk/OAuthScope.cs
@@ -57,6 +57,7 @@
         [OAuthScope("Payment Context")] PaymentContext,
         [OAuthScope("forward")] Forward,
         [OAuthScope("forward:secrets")] ForwardSecrets,
+        [OAuthScope("identity-verification")] IdentityVerification,
         [OAuthScope("vault:network-tokens")] VaultNetworkTokens,
 
         [OAuthScope("payments:search")] PaymentsSearch

--- a/test/CheckoutSdkTest/CheckoutConfigurationTest.cs
+++ b/test/CheckoutSdkTest/CheckoutConfigurationTest.cs
@@ -25,6 +25,8 @@ namespace Checkout
         [InlineData("abc1", "https://abc1.api.sandbox.checkout.com/", "https://abc1.access.sandbox.checkout.com/connect/token")]
         [InlineData("12345domain", "https://12345domain.api.sandbox.checkout.com/", "https://12345domain.access.sandbox.checkout.com/connect/token")]
         [InlineData("1234doma", "https://1234doma.api.sandbox.checkout.com/", "https://1234doma.access.sandbox.checkout.com/connect/token")]
+        [InlineData("test-123", "https://test-123.api.sandbox.checkout.com/", "https://test-123.access.sandbox.checkout.com/connect/token")]
+        [InlineData("pl-abc123", "https://pl-abc123.api.sandbox.checkout.com/", "https://pl-abc123.access.sandbox.checkout.com/connect/token")]
         public void ShouldCreateConfigurationWithSubdomain(string subdomain, string expectedApiUri, string expectedAuthUri)
         {
             var credentials = new StaticKeysSdkCredentials(ValidDefaultSk, ValidDefaultPk);
@@ -46,6 +48,9 @@ namespace Checkout
         [InlineData(" - ", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
         [InlineData("a b", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
         [InlineData("ab c1", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
+        [InlineData("foo-", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
+        [InlineData("-foo", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
+        [InlineData("ABC123", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
         public void ShouldCreateConfigurationWithBadSubdomain(string subdomain, string expectedApiUri, string expectedAuthUri)
         {
             var credentials = new StaticKeysSdkCredentials(ValidDefaultSk, ValidDefaultPk);
@@ -59,7 +64,7 @@ namespace Checkout
             configuration.EnvironmentSubdomain.AuthorizationUri.ToString().ShouldBe(expectedAuthUri);
             configuration.SdkCredentials.ShouldBeAssignableTo(typeof(StaticKeysSdkCredentials));
         }
-        
+
         [Theory]
         [InlineData("1234prod", "https://1234prod.api.checkout.com/", "https://1234prod.access.checkout.com/connect/token")]
         [InlineData("prodcompany", "https://prodcompany.api.checkout.com/", "https://prodcompany.access.checkout.com/connect/token")]
@@ -75,6 +80,22 @@ namespace Checkout
             configuration.EnvironmentSubdomain.ApiUri.ToString().ShouldBe(expectedApiUri);
             configuration.EnvironmentSubdomain.AuthorizationUri.ToString().ShouldBe(expectedAuthUri);
             configuration.SdkCredentials.ShouldBeAssignableTo(typeof(StaticKeysSdkCredentials));
+        }
+
+        [Fact]
+        public void ShouldHaveCorrectForwardAndIdentityUrisForSandbox()
+        {
+            var attr = Environment.Sandbox.GetAttribute<EnvironmentAttribute>();
+            attr.ForwardApiUri.ToString().ShouldBe("https://forward.sandbox.checkout.com/");
+            attr.IdentityApiUri.ToString().ShouldBe("https://identity-verification.sandbox.checkout.com/");
+        }
+
+        [Fact]
+        public void ShouldHaveCorrectForwardAndIdentityUrisForProduction()
+        {
+            var attr = Environment.Production.GetAttribute<EnvironmentAttribute>();
+            attr.ForwardApiUri.ToString().ShouldBe("https://forward.checkout.com/");
+            attr.IdentityApiUri.ToString().ShouldBe("https://identity-verification.checkout.com/");
         }
     }
 }

--- a/test/CheckoutSdkTest/CheckoutConfigurationTest.cs
+++ b/test/CheckoutSdkTest/CheckoutConfigurationTest.cs
@@ -25,7 +25,7 @@ namespace Checkout
         [InlineData("abc1", "https://abc1.api.sandbox.checkout.com/", "https://abc1.access.sandbox.checkout.com/connect/token")]
         [InlineData("12345domain", "https://12345domain.api.sandbox.checkout.com/", "https://12345domain.access.sandbox.checkout.com/connect/token")]
         [InlineData("1234doma", "https://1234doma.api.sandbox.checkout.com/", "https://1234doma.access.sandbox.checkout.com/connect/token")]
-        [InlineData("test-123", "https://test-123.api.sandbox.checkout.com/", "https://test-123.access.sandbox.checkout.com/connect/token")]
+        [InlineData("pl-vkuhvk4v", "https://pl-vkuhvk4v.api.sandbox.checkout.com/", "https://pl-vkuhvk4v.access.sandbox.checkout.com/connect/token")]
         [InlineData("pl-abc123", "https://pl-abc123.api.sandbox.checkout.com/", "https://pl-abc123.access.sandbox.checkout.com/connect/token")]
         public void ShouldCreateConfigurationWithSubdomain(string subdomain, string expectedApiUri, string expectedAuthUri)
         {
@@ -51,6 +51,9 @@ namespace Checkout
         [InlineData("foo-", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
         [InlineData("-foo", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
         [InlineData("ABC123", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
+        [InlineData("test-123", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
+        [InlineData("foo-bar", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
+        [InlineData("pl-", "https://api.sandbox.checkout.com/", "https://access.sandbox.checkout.com/connect/token")]
         public void ShouldCreateConfigurationWithBadSubdomain(string subdomain, string expectedApiUri, string expectedAuthUri)
         {
             var credentials = new StaticKeysSdkCredentials(ValidDefaultSk, ValidDefaultPk);

--- a/test/CheckoutSdkTest/SubdomainFunctionalityTest.cs
+++ b/test/CheckoutSdkTest/SubdomainFunctionalityTest.cs
@@ -38,12 +38,22 @@ namespace CheckoutSdkTest
         [Fact]
         public void ShouldNotAddSubdomainForInvalidSubdomainFormat()
         {
-            var invalidSubdomain = "invalid-subdomain";
+            var invalidSubdomain = "invalid_subdomain!";
             var environmentSubdomain = new EnvironmentSubdomain(Environment.Sandbox, invalidSubdomain);
-            
+
             // Should fallback to original URLs without subdomain
             Assert.Equal("https://api.sandbox.checkout.com/", environmentSubdomain.ApiUri.ToString());
             Assert.Equal("https://access.sandbox.checkout.com/connect/token", environmentSubdomain.AuthorizationUri.ToString());
+        }
+
+        [Fact]
+        public void ShouldAddSubdomainForHyphenatedSubdomain()
+        {
+            var subdomain = "pl-abc123";
+            var environmentSubdomain = new EnvironmentSubdomain(Environment.Sandbox, subdomain);
+
+            Assert.Equal($"https://{subdomain}.api.sandbox.checkout.com/", environmentSubdomain.ApiUri.ToString());
+            Assert.Equal($"https://{subdomain}.access.sandbox.checkout.com/connect/token", environmentSubdomain.AuthorizationUri.ToString());
         }
     }
 }

--- a/test/CheckoutSdkTest/SubdomainFunctionalityTest.cs
+++ b/test/CheckoutSdkTest/SubdomainFunctionalityTest.cs
@@ -47,9 +47,9 @@ namespace CheckoutSdkTest
         }
 
         [Fact]
-        public void ShouldAddSubdomainForHyphenatedSubdomain()
+        public void ShouldAddSubdomainForPrivateLinkPrefix()
         {
-            var subdomain = "pl-abc123";
+            var subdomain = "pl-vkuhvk4v";
             var environmentSubdomain = new EnvironmentSubdomain(Environment.Sandbox, subdomain);
 
             Assert.Equal($"https://{subdomain}.api.sandbox.checkout.com/", environmentSubdomain.ApiUri.ToString());


### PR DESCRIPTION
## Summary

The forward service and the identity-verification services (applicants, identity-verification, AML screening, face-authentication, ID document verification) live on their own hosts in the swagger spec, not under `api.checkout.com`. This PR adds dedicated URIs for both and routes the corresponding clients through them. It also tightens the subdomain validation regex to match the AWS PrivateLink prefix format documented at https://www.checkout.com/docs/developer-resources/api/private-connections/aws-privatelink — `^(?:pl-)?[a-z0-9]+$` (alphanumeric, optionally prefixed by the literal `pl-`). Finally, it exposes the `identity-verification` OAuth scope as a typed enum constant and adds a 100ms timeout to the subdomain Regex (SonarLint S6444).

## Changes

- `src/CheckoutSdk/Environment.cs` — adds `ForwardApiUri` and `IdentityApiUri` to the `Sandbox`/`Production` `[Environment]` attributes; tightens subdomain regex to `^(?:pl-)?[a-z0-9]+$` with a 100ms timeout
- `src/CheckoutSdk/EnvironmentAttribute.cs` — adds `ForwardApiUri`/`IdentityApiUri` properties and constructor parameters
- `src/CheckoutSdk/OAuthScope.cs` — adds `[OAuthScope("identity-verification")] IdentityVerification`
- `src/CheckoutSdk/CheckoutApi.cs` — adds `ForwardApiClient` and `IdentityApiClient` factory methods; routes `_forwardClient` to forward URI; caches the identity `ApiClient` once and reuses it across `_applicantsClient`, `_amlScreeningClient`, `_faceAuthenticationClient`, `_idDocumentVerificationClient`, `_identityVerificationClient` (avoids the .NET HttpClient anti-pattern of multiple instances per host)
- `test/CheckoutSdkTest/CheckoutConfigurationTest.cs` — updates subdomain corpus: removes `test-123` from accepted, adds `pl-vkuhvk4v` (docs example) to accepted, adds `test-123`/`foo-bar`/`pl-` to rejected; adds `ShouldHaveCorrectForwardAndIdentityUrisForSandbox`/`…ForProduction`
- `test/CheckoutSdkTest/SubdomainFunctionalityTest.cs` — replaces the "invalid_subdomain" test value with one that's actually rejected (`invalid_subdomain!`); renames the hyphenated happy-path test to `ShouldAddSubdomainForPrivateLinkPrefix` and uses the docs example

## API Reference

- `https://forward.checkout.com` / `https://forward.sandbox.checkout.com` — forward service (`POST /forward` *(beta)*, `GET /forward/{id}` *(beta)*, `POST /forward/secrets`, `GET|POST|DELETE /forward/secrets/{name}`). Scopes: `forward` (plus `forward:secrets` for secrets endpoints).
- `https://identity-verification.checkout.com` / `https://identity-verification.sandbox.checkout.com` — identity services (`/applicants`, `/identity-verifications` *(beta)*, `/aml-verifications` *(beta)*, `/face-authentications` *(beta)*, `/id-document-verifications` *(beta)*). Scope: `identity-verification`.
- `https://pl-{prefix}.api.{sandbox.,}checkout.com` — AWS PrivateLink subdomain format

## Breaking changes

- `EnvironmentAttribute` constructor now requires `forwardApiUri` and `identityApiUri` string parameters. Any code decorating a custom enum with `[Environment(…)]` must add them.
- The subdomain regex is now stricter: arbitrary hyphenated subdomains like `test-123` or `foo-bar-baz` are rejected. Only plain alphanumeric or the literal PrivateLink form (`pl-{prefix}`) are accepted.

## README

Not affected.