### PR TITLE
IssuingClient - Paremeters fix, scheduling card revocations and querying control profiles

### DIFF
--- a/src/CheckoutSdk/Issuing/ControlProfiles/Requests/ControlProfileQueryTarget.cs
+++ b/src/CheckoutSdk/Issuing/ControlProfiles/Requests/ControlProfileQueryTarget.cs
@@ -1,0 +1,16 @@
+namespace Checkout.Issuing.ControlProfiles.Requests
+{
+    /// <summary>
+    /// Query parameters for retrieving a list of control profiles applied to the specified card.
+    /// </summary>
+    public class ControlProfileQueryTarget
+    {
+        /// <summary>
+        /// The card's unique identifier.
+        /// ^crd_[a-z0-9]{26}$
+        /// 30 characters
+        /// [Optional]
+        /// </summary>
+        public string TargetId { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Issuing/IIssuingClient.Cards.cs
+++ b/src/CheckoutSdk/Issuing/IIssuingClient.Cards.cs
@@ -53,7 +53,8 @@ namespace Checkout.Issuing
         Task<Resource> RevokeCard(string cardId, RevokeCardRequest revokeCardRequest,
             CancellationToken cancellationToken = default);
         
-        Task<Resource> ScheduleCardRevocation(ScheduleCardRevocationRequest scheduleCardRevocationRequest,
+        Task<Resource> ScheduleCardRevocation(string cardId,
+            ScheduleCardRevocationRequest scheduleCardRevocationRequest,
             CancellationToken cancellationToken = default);
         
         Task<Resource> DeleteScheduledRevocation(string cardId,

--- a/src/CheckoutSdk/Issuing/IIssuingClient.ControlProfiles.cs
+++ b/src/CheckoutSdk/Issuing/IIssuingClient.ControlProfiles.cs
@@ -12,7 +12,7 @@ namespace Checkout.Issuing
         Task<ControlProfileResponse> CreateControlProfile(ControlProfileRequest controlProfileRequest,
             CancellationToken cancellationToken = default);
 
-        Task<ControlProfilesResponse> GetAllControlProfiles(string targetId,
+        Task<ControlProfilesResponse> GetAllControlProfiles(ControlProfileQueryTarget query,
             CancellationToken cancellationToken = default);
 
         Task<ControlProfileResponse> GetControlProfileDetails(string controlProfileId,

--- a/src/CheckoutSdk/Issuing/IssuingClient.Cards.cs
+++ b/src/CheckoutSdk/Issuing/IssuingClient.Cards.cs
@@ -140,12 +140,13 @@ namespace Checkout.Issuing
         }
 
         public Task<Resource> ScheduleCardRevocation(
+            string cardId, 
             ScheduleCardRevocationRequest scheduleCardRevocationRequest,
             CancellationToken cancellationToken = default)
         {
-            CheckoutUtils.ValidateParams("scheduleCardRevocationRequest", scheduleCardRevocationRequest);
+            CheckoutUtils.ValidateParams("cardId", cardId, "scheduleCardRevocationRequest", scheduleCardRevocationRequest);
             return ApiClient.Post<Resource>(
-                BuildPath(IssuingPath, CardsPath, ScheduleRevocation),
+                BuildPath(IssuingPath, CardsPath, cardId, ScheduleRevocation),
                 SdkAuthorization(),
                 scheduleCardRevocationRequest,
                 cancellationToken

--- a/src/CheckoutSdk/Issuing/IssuingClient.ControlProfiles.cs
+++ b/src/CheckoutSdk/Issuing/IssuingClient.ControlProfiles.cs
@@ -20,12 +20,13 @@ namespace Checkout.Issuing
             );
         }
 
-        public Task<ControlProfilesResponse> GetAllControlProfiles(string targetId, CancellationToken cancellationToken = default)
+        public Task<ControlProfilesResponse> GetAllControlProfiles(ControlProfileQueryTarget query, CancellationToken cancellationToken = default)
         {
-            CheckoutUtils.ValidateParams("targetId", targetId);
-            return ApiClient.Get<ControlProfilesResponse>(
+            CheckoutUtils.ValidateParams("query", query);
+            return ApiClient.Query<ControlProfilesResponse>(
                 BuildPath(IssuingPath, ControlsPath, ControlProfilesPath),
                 SdkAuthorization(),
+                query,
                 cancellationToken
             );
         }

--- a/test/CheckoutSdkTest/Issuing/Cards/CardClientTest.cs
+++ b/test/CheckoutSdkTest/Issuing/Cards/CardClientTest.cs
@@ -284,7 +284,7 @@ namespace Checkout.Issuing.Cards
 
             _apiClient.Setup(apiClient =>
                     apiClient.Post<Resource>(
-                        "issuing/cards/schedule-revocation",
+                        "issuing/cards/card_id/schedule-revocation",
                         _authorization,
                         scheduleRequest,
                         CancellationToken.None,
@@ -293,7 +293,7 @@ namespace Checkout.Issuing.Cards
 
             IIssuingClient client = new IssuingClient(_apiClient.Object, _configuration.Object);
 
-            Resource response = await client.ScheduleCardRevocation(scheduleRequest, CancellationToken.None);
+            Resource response = await client.ScheduleCardRevocation("card_id", scheduleRequest, CancellationToken.None);
 
             response.ShouldNotBeNull();
             response.ShouldBeSameAs(resourceResponse);

--- a/test/CheckoutSdkTest/Issuing/Cards/CardIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/Cards/CardIntegrationTest.cs
@@ -321,12 +321,13 @@ namespace Checkout.Issuing.Cards
         [Fact(Skip = "Avoid creating cards all the time")]
         private async Task ShouldScheduleCardRevocation()
         {
+            AbstractCardCreateResponse abstractCard = _abstractCardRequest;
             var scheduleRequest = new ScheduleCardRevocationRequest
             {
                 RevocationDate = System.DateTime.UtcNow.AddDays(7).ToString("yyyy-MM-dd")
             };
 
-            var resourceResponse = await Api.IssuingClient().ScheduleCardRevocation(scheduleRequest);
+            var resourceResponse = await Api.IssuingClient().ScheduleCardRevocation(abstractCard.Id, scheduleRequest);
 
             resourceResponse.HttpStatusCode.ShouldBe(200);
             resourceResponse.Body.ShouldNotBeNull();

--- a/test/CheckoutSdkTest/Issuing/ControlProfiles/ControlProfilesClientTest.cs
+++ b/test/CheckoutSdkTest/Issuing/ControlProfiles/ControlProfilesClientTest.cs
@@ -53,17 +53,18 @@ namespace Checkout.Issuing.ControlProfiles
         [Fact]
         private async Task ShouldGetAllControlProfiles()
         {
+            ControlProfileQueryTarget query = new ControlProfileQueryTarget { TargetId = "target_id" };
             ControlProfilesResponse controlProfilesResponse = new ControlProfilesResponse();
 
             _apiClient.Setup(apiClient =>
-                    apiClient.Get<ControlProfilesResponse>("issuing/controls/control-profiles", _authorization,
-                        CancellationToken.None))
+                    apiClient.Query<ControlProfilesResponse>("issuing/controls/control-profiles", _authorization,
+                        query, CancellationToken.None))
                 .ReturnsAsync(() => controlProfilesResponse);
 
             IIssuingClient client =
                 new IssuingClient(_apiClient.Object, _configuration.Object);
 
-            ControlProfilesResponse response = await client.GetAllControlProfiles("target_id");
+            ControlProfilesResponse response = await client.GetAllControlProfiles(query);
 
             response.ShouldNotBeNull();
             response.ShouldBeSameAs(controlProfilesResponse);

--- a/test/CheckoutSdkTest/Issuing/ControlProfiles/ControlProfilesIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/ControlProfiles/ControlProfilesIntegrationTest.cs
@@ -41,7 +41,8 @@ namespace Checkout.Issuing.ControlProfiles
         [Fact(Skip = "Use on demand")]
         private async Task ShouldGetAllControlProfiles()
         {
-            ControlProfilesResponse response = await Api.IssuingClient().GetAllControlProfiles(_controlProfile.Id);
+            ControlProfilesResponse response = await Api.IssuingClient().GetAllControlProfiles(
+                new ControlProfileQueryTarget { TargetId = _controlProfile.Id });
             response.ShouldNotBeNull();
             response.ControlProfiles.ShouldNotBeNull();
 


### PR DESCRIPTION
This pull request refactors and improves the APIs for scheduling card revocations and querying control profiles in the Issuing SDK. The changes enhance type safety, clarify method signatures, and update tests to match the new interfaces.

**API Improvements and Refactoring:**

* The `ScheduleCardRevocation` method now explicitly requires a `cardId` parameter, both in the interface and implementation, ensuring the card being revoked is clearly specified. [[1]](diffhunk://#diff-258eb194987feba8243b5b51dae1af45581798574f8285b1256761d6e6b4bbe3L56-R57) [[2]](diffhunk://#diff-c8f873f8d0de6e849547601d5f43ef8fb91d30c2c7c6ae22b5c6a57ad75b085fR143-R149)
* The `GetAllControlProfiles` method now takes a `ControlProfileQueryTarget` object instead of a raw string, allowing for more flexible and extensible query parameters. [[1]](diffhunk://#diff-004490c64c2a9d542e7d8e56d6e97d0963c15f0bbb1346dbbd2201a23705abc7L15-R15) [[2]](diffhunk://#diff-54e7cb00381126a0f741cdac693d7746dbf9ed7c4a6ab9874a9d7ec4af2cb1f7L23-R29)
* Introduced the `ControlProfileQueryTarget` class to encapsulate query parameters for control profile retrieval, improving code clarity and future extensibility.

**Test Updates:**

* Updated all relevant unit and integration tests to use the new method signatures and query object, ensuring tests accurately reflect the refactored API and maintain coverage. [[1]](diffhunk://#diff-a484dc3baa6f944568ebd28b33fd4d06cf0460f5390db3e7b4a0fe8a0f328ea2L287-R287) [[2]](diffhunk://#diff-a484dc3baa6f944568ebd28b33fd4d06cf0460f5390db3e7b4a0fe8a0f328ea2L296-R296) [[3]](diffhunk://#diff-2a883e04af2542a919c70d27da33bbe7c7d8741815bc45c96f8a2629c0cd54e6R324-R330) [[4]](diffhunk://#diff-9ec85daffa2a5bae5885cb020a5e39bf254cef5679862dfe2fb64efb66af540dR56-R67) [[5]](diffhunk://#diff-f4102e11ebce3e9829eeeeb044127d5a7beee4398efcc4efa95ffd3d66da95e3L44-R45)