### PR TITLE
New product Id for card test

### DIFF
--- a/test/CheckoutSdkTest/Issuing/ControlGroups/ControlGroupsIntegrationTest.cs
+++ b/test/CheckoutSdkTest/Issuing/ControlGroups/ControlGroupsIntegrationTest.cs
@@ -16,15 +16,6 @@ namespace Checkout.Issuing.ControlGroups
 {
     public class ControlGroupsIntegrationTest : IssuingCommon, IAsyncLifetime
     {
-        // These tests provision a new card on every run as a prerequisite. The shared sandbox
-        // card product has exhausted its account ranges (the API rejects card creation with
-        // 422 "card_product_account_range_full"), so the tests cannot complete their setup.
-        // Skipped to keep the suite green until a card product with available account range is
-        // provisioned.
-        private const string SkipReason =
-            "Sandbox card product account range is full (card_product_account_range_full); " +
-            "requires a card product with available account range";
-
         private CardholderResponse _cardholder;
         private AbstractCardCreateRequest _cardRequest;
 
@@ -39,7 +30,7 @@ namespace Checkout.Issuing.ControlGroups
             return Task.CompletedTask;
         }
 
-        [Fact(Skip = SkipReason)]
+        [Fact]
         public async Task CreateControlGroup_ShouldReturnValidResponse()
         {
             // Act
@@ -51,7 +42,7 @@ namespace Checkout.Issuing.ControlGroups
             AssertControlGroupCreated(response, request);
         }
 
-        [Fact(Skip = SkipReason)]
+        [Fact]
         public async Task GetTargetControlGroups_ShouldReturnValidResponse()
         {
             // Arrange
@@ -67,7 +58,7 @@ namespace Checkout.Issuing.ControlGroups
             AssertTargetControlGroupsRetrieved(response, controlGroup.Id);
         }
 
-        [Fact(Skip = SkipReason)]
+        [Fact]
         public async Task GetControlGroupDetails_ShouldReturnValidResponse()
         {
             // Arrange
@@ -82,7 +73,7 @@ namespace Checkout.Issuing.ControlGroups
             AssertControlGroupDetailsRetrieved(response, controlGroup);
         }
 
-        [Fact(Skip = SkipReason)]
+        [Fact]
         public async Task RemoveControlGroup_ShouldReturnValidResponse()
         {
             // Arrange
@@ -97,7 +88,7 @@ namespace Checkout.Issuing.ControlGroups
             AssertControlGroupRemoved(response, createResponse.Id);
         }
 
-        [Fact(Skip = SkipReason)]
+        [Fact]
         public async Task ControlGroupFlow_ShouldWorkEndToEnd()
         {
             // Arrange - Create a new cardholder and card for this flow test

--- a/test/CheckoutSdkTest/Issuing/IssuingCommon.cs
+++ b/test/CheckoutSdkTest/Issuing/IssuingCommon.cs
@@ -10,7 +10,12 @@ namespace Checkout.Issuing
     public class IssuingCommon : SandboxTestFixture
     {
         protected readonly ICheckoutApi Api;
-        protected readonly string ProductIdOk = "pro_3fn6pv2ikshurn36dbd3iysyha";
+        
+        // currently not used: Sandbox card product account range is full error (card_product_account_range_full)
+        protected readonly string OldProductIdOk = "pro_3fn6pv2ikshurn36dbd3iysyha";
+
+        // new product with available account range created for testing purposes
+        protected readonly string ProductIdOk = "pro_gfp2kpog3ztutpgtpu4jj36n7i";
         protected readonly string ProductIdBad = "pro_2ebzpnw3wvcefnu7fqglqmg56m";
 
         protected IssuingCommon() : base(PlatformType.DefaultOAuth)


### PR DESCRIPTION
This pull request re-enables previously skipped integration tests for the Control Groups functionality in the issuing module by updating the test card product to one with available account ranges. The changes ensure that all related tests can now run successfully in the sandbox environment.

**Test re-enablement and product update:**

* Updated `ProductIdOk` in `IssuingCommon` to use a new card product (`pro_gfp2kpog3ztutpgtpu4jj36n7i`) with available account ranges for testing, and preserved the old product ID as `OldProductIdOk` for reference.
* Removed the `SkipReason` constant and the `[Fact(Skip = SkipReason)]` attribute from all affected tests in `ControlGroupsIntegrationTest.cs`, re-enabling the following tests: `CreateControlGroup_ShouldReturnValidResponse`, `GetTargetControlGroups_ShouldReturnValidResponse`, `GetControlGroupDetails_ShouldReturnValidResponse`, `RemoveControlGroup_ShouldReturnValidResponse`, and `ControlGroupFlow_ShouldWorkEndToEnd`. [[1]](diffhunk://#diff-f85815c9664bec0b18f8cc1ba572e4e8252578b84141a5bbb4fefadc4f342108L19-L27) [[2]](diffhunk://#diff-f85815c9664bec0b18f8cc1ba572e4e8252578b84141a5bbb4fefadc4f342108L42-R33) [[3]](diffhunk://#diff-f85815c9664bec0b18f8cc1ba572e4e8252578b84141a5bbb4fefadc4f342108L54-R45) [[4]](diffhunk://#diff-f85815c9664bec0b18f8cc1ba572e4e8252578b84141a5bbb4fefadc4f342108L70-R61) [[5]](diffhunk://#diff-f85815c9664bec0b18f8cc1ba572e4e8252578b84141a5bbb4fefadc4f342108L85-R76) [[6]](diffhunk://#diff-f85815c9664bec0b18f8cc1ba572e4e8252578b84141a5bbb4fefadc4f342108L100-R91)