### PR TITLE
fix: nullable 3DS browser Java/Javascript flags so explicit false serializes

### DIFF
--- a/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/ChannelData/BrowserChannelData/BrowserChannelData.cs
+++ b/src/CheckoutSdk/Authentication/Standalone/POSTSessions/Requests/RequestASessionRequest/ChannelData/BrowserChannelData/BrowserChannelData.cs
@@ -27,7 +27,7 @@ namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessi
         /// navigator.javaEnabled property.
         /// [Required]
         /// </summary>
-        public bool JavaEnabled { get; set; }
+        public bool? JavaEnabled { get; set; }
 
         /// <summary>
         /// Default: true Boolean that represents the ability of the cardholder's browser to execute Javascript. Value
@@ -36,7 +36,7 @@ namespace Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessi
         /// disregarded.
         /// [Required]
         /// </summary>
-        public bool JavascriptEnabled { get; set; } = true;
+        public bool? JavascriptEnabled { get; set; }
 
         /// <summary>
         /// Value representing the browser language as defined in IETF BCP47. Returned from the navigator.language

--- a/src/CheckoutSdk/Authentication/Standalone/PUTSessionsIdCollectData/Requests/BrowserRequest/BrowserRequest.cs
+++ b/src/CheckoutSdk/Authentication/Standalone/PUTSessionsIdCollectData/Requests/BrowserRequest/BrowserRequest.cs
@@ -27,7 +27,7 @@ namespace Checkout.Authentication.Standalone.PUTSessionsIdCollectData.Requests.B
         /// navigator.javaEnabled property.
         /// [Required]
         /// </summary>
-        public bool JavaEnabled { get; set; }
+        public bool? JavaEnabled { get; set; }
 
         /// <summary>
         /// Default: true Boolean that represents the ability of the cardholder's browser to execute Javascript. Value
@@ -36,7 +36,7 @@ namespace Checkout.Authentication.Standalone.PUTSessionsIdCollectData.Requests.B
         /// disregarded.
         /// [Required]
         /// </summary>
-        public bool JavascriptEnabled { get; set; } = true;
+        public bool? JavascriptEnabled { get; set; }
 
         /// <summary>
         /// Value representing the browser language as defined in IETF BCP47. Returned from the navigator.language

--- a/test/CheckoutSdkTest/Authentification/Standalone/BrowserChannelDataSerializationTest.cs
+++ b/test/CheckoutSdkTest/Authentification/Standalone/BrowserChannelDataSerializationTest.cs
@@ -1,0 +1,64 @@
+using Checkout.Authentication.Standalone.POSTSessions.Requests.RequestASessionRequest.ChannelData.BrowserChannelData;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.Authentification.Standalone
+{
+    public class BrowserChannelDataSerializationTest
+    {
+        private static readonly JsonSerializer Serializer = new JsonSerializer();
+
+        [Fact]
+        public void ShouldSerializeExplicitFalseFlags()
+        {
+            var data = new BrowserChannelData
+            {
+                JavaEnabled = false,
+                JavascriptEnabled = false
+            };
+
+            var json = Serializer.Serialize(data);
+
+            json.ShouldContain("\"java_enabled\":false");
+            json.ShouldContain("\"javascript_enabled\":false");
+        }
+
+        [Fact]
+        public void ShouldSerializeExplicitTrueFlags()
+        {
+            var data = new BrowserChannelData
+            {
+                JavaEnabled = true,
+                JavascriptEnabled = true
+            };
+
+            var json = Serializer.Serialize(data);
+
+            json.ShouldContain("\"java_enabled\":true");
+            json.ShouldContain("\"javascript_enabled\":true");
+        }
+
+        [Fact]
+        public void ShouldOmitUnsetFlags()
+        {
+            var data = new BrowserChannelData();
+
+            var json = Serializer.Serialize(data);
+
+            json.ShouldNotContain("java_enabled");
+            json.ShouldNotContain("javascript_enabled");
+        }
+
+        [Fact]
+        public void ShouldRoundTripExplicitFalse()
+        {
+            var original = new BrowserChannelData { JavaEnabled = false, JavascriptEnabled = false };
+
+            var json = Serializer.Serialize(original);
+            var deserialized = (BrowserChannelData)Serializer.Deserialize(json, typeof(BrowserChannelData));
+
+            deserialized.JavaEnabled.ShouldBe(false);
+            deserialized.JavascriptEnabled.ShouldBe(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Part of a cross-SDK field-coverage sweep against the Checkout.com swagger spec.

### 1. Missing request fields (`authorization_type`, `payment_plan`)
Swagger added `authorization_type` and `payment_plan` to `HostedPaymentsRequest`, `PaymentLinksRequest`, and `CreatePaymentSessionsBaseRequest`. The .NET SDK already carries these on `HostedPaymentRequest`, `PaymentLinkRequest`, and `PaymentSessionInfo` (the Flow create base), reusing the existing `AuthorizationType` enum and `PaymentPlan` type, with schema tests already in place. No code change needed — verified as covered.

### 2. Optional bool serialization bug (this PR's change)
`JavaEnabled` and `JavascriptEnabled` on `BrowserChannelData` (and the equivalent `BrowserRequest`) were non-nullable `bool`, and `JavascriptEnabled` defaulted to `= true`. With `NullValueHandling.Ignore`, an unset value could not be distinguished from an explicit `false`, and the `= true` default was always emitted even when the caller never set it.

Changed both fields to `bool?` and removed the `= true` default, matching the `bool?` pattern already used by `Payments/Device`. Now:
- unset flags are omitted from the payload,
- an explicit `false` serializes correctly,
- an explicit `true` still serializes.

### Tests
Added `BrowserChannelDataSerializationTest` covering explicit true/false snake_case serialization, omission when unset, and round-trip of explicit false.

### Build / test status
- `dotnet build` (net8.0): 0 errors.
- `dotnet test` filtered to the affected serialization tests: 15 passed, 0 failed.