### PR TITLE
fix: Make SubType nullable

### DIFF
--- a/src/CheckoutSdk/Payments/Request/Product.cs
+++ b/src/CheckoutSdk/Payments/Request/Product.cs
@@ -4,7 +4,8 @@
     {
         public ItemType Type { get; set; }
         
-        public ItemSubType SubType { get; set; }
+        public ItemSubType? SubType { get; set; }
+
         public string Name { get; set; }
 
         public long? Quantity { get; set; }


### PR DESCRIPTION
The current implementation of the given property `SubType` on `Product` may lead to unexpected declines with certain banks due to the default value of `ItemSubType` being `Blockchain`.

As we cannot explicitly override this property (as it is non-nullable), this is being sent for any payment requests that include a product item.

As per your support team:

> Our platform interprets sub_type: "blockchain" as a blockchain/digital asset purchase and sets a corresponding indicator in the Visa authorisation message (field DE60.4 = 3). Issuers such as Bank of Scotland do not accept this indicator on standard retail transactions and declines as a result.

This fix makes the `SubType` property nullable.