### PR TITLE
feat(identities): add Address Document Verification (Adv) endpoints

### DIFF
--- a/src/CheckoutSdk/CheckoutApi.cs
+++ b/src/CheckoutSdk/CheckoutApi.cs
@@ -16,6 +16,7 @@ using Checkout.Identities.Applicants;
 using Checkout.Identities.AmlScreening;
 using Checkout.Identities.FaceAuthentication;
 using Checkout.Identities.IdDocumentVerification;
+using Checkout.Identities.AddressDocumentVerification;
 using Checkout.Identities.IdentityVerification;
 using Checkout.Instruments;
 using Checkout.Metadata;
@@ -63,6 +64,7 @@ namespace Checkout
         private readonly IAmlScreeningClient _amlScreeningClient;
         private readonly IFaceAuthenticationClient _faceAuthenticationClient;
         private readonly IIdDocumentVerificationClient _idDocumentVerificationClient;
+        private readonly IAddressDocumentVerificationClient _addressDocumentVerificationClient;
         private readonly IIdentityVerificationClient _identityVerificationClient;
         private readonly INetworkTokensClient _networkTokensClient;
         private readonly IPaymentSetupsClient _paymentSetupsClient;
@@ -108,6 +110,7 @@ namespace Checkout
             _amlScreeningClient = new AmlScreeningClient(identityApiClient, configuration);
             _faceAuthenticationClient = new FaceAuthenticationClient(identityApiClient, configuration);
             _idDocumentVerificationClient = new IdDocumentVerificationClient(identityApiClient, configuration);
+            _addressDocumentVerificationClient = new AddressDocumentVerificationClient(identityApiClient, configuration);
             _identityVerificationClient = new IdentityVerificationClient(identityApiClient, configuration);
             _networkTokensClient = new NetworkTokensClient(baseApiClient, configuration);
             _paymentSetupsClient = new PaymentSetupsClient(baseApiClient, configuration);
@@ -288,6 +291,11 @@ namespace Checkout
         public IIdDocumentVerificationClient IdDocumentVerificationClient()
         {
             return _idDocumentVerificationClient;
+        }
+
+        public IAddressDocumentVerificationClient AddressDocumentVerificationClient()
+        {
+            return _addressDocumentVerificationClient;
         }
 
         public IIdentityVerificationClient IdentityVerificationClient()

--- a/src/CheckoutSdk/ICheckoutApi.cs
+++ b/src/CheckoutSdk/ICheckoutApi.cs
@@ -16,6 +16,7 @@ using Checkout.Identities.Applicants;
 using Checkout.Identities.AmlScreening;
 using Checkout.Identities.FaceAuthentication;
 using Checkout.Identities.IdDocumentVerification;
+using Checkout.Identities.AddressDocumentVerification;
 using Checkout.Identities.IdentityVerification;
 using Checkout.Instruments;
 using Checkout.Metadata;
@@ -87,6 +88,8 @@ namespace Checkout
         IFaceAuthenticationClient FaceAuthenticationClient();
         
         IIdDocumentVerificationClient IdDocumentVerificationClient();
+
+        IAddressDocumentVerificationClient AddressDocumentVerificationClient();
         
         IIdentityVerificationClient IdentityVerificationClient();
         

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/AddressDocumentVerificationClient.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/AddressDocumentVerificationClient.cs
@@ -1,0 +1,71 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Checkout.Identities.AddressDocumentVerification.Requests;
+using Checkout.Identities.AddressDocumentVerification.Responses;
+
+namespace Checkout.Identities.AddressDocumentVerification
+{
+    public class AddressDocumentVerificationClient : AbstractClient, IAddressDocumentVerificationClient
+    {
+        private const string AddressDocumentVerificationsPath = "address-document-verifications";
+        private const string AnonymizePath = "anonymize";
+        private const string AttemptsPath = "attempts";
+        private const string ReportPath = "pdf-report";
+
+        public AddressDocumentVerificationClient(IApiClient apiClient, CheckoutConfiguration configuration) :
+            base(apiClient, configuration, SdkAuthorizationType.SecretKeyOrOAuth)
+        {
+        }
+
+        public Task<AddressDocumentVerificationResponse> CreateAddressDocumentVerification(AddressDocumentVerificationRequest addressDocumentVerificationRequest, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("addressDocumentVerificationRequest", addressDocumentVerificationRequest);
+            return ApiClient.Post<AddressDocumentVerificationResponse>(AddressDocumentVerificationsPath,
+                SdkAuthorization(), addressDocumentVerificationRequest, cancellationToken);
+        }
+
+        public Task<AddressDocumentVerificationResponse> GetAddressDocumentVerification(string addressDocumentVerificationId, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+            return ApiClient.Get<AddressDocumentVerificationResponse>(BuildPath(AddressDocumentVerificationsPath, addressDocumentVerificationId),
+                SdkAuthorization(), cancellationToken);
+        }
+
+        public Task<AddressDocumentVerificationResponse> AnonymizeAddressDocumentVerification(string addressDocumentVerificationId, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+            return ApiClient.Post<AddressDocumentVerificationResponse>(BuildPath(AddressDocumentVerificationsPath, addressDocumentVerificationId, AnonymizePath),
+                SdkAuthorization(), (object)null, cancellationToken);
+        }
+
+        public Task<AddressDocumentVerificationAttemptResponse> CreateAddressDocumentVerificationAttempt(string addressDocumentVerificationId, AddressDocumentVerificationAttemptRequest attemptRequest, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+            CheckoutUtils.ValidateParams("attemptRequest", attemptRequest);
+            return ApiClient.Post<AddressDocumentVerificationAttemptResponse>(BuildPath(AddressDocumentVerificationsPath, addressDocumentVerificationId, AttemptsPath),
+                SdkAuthorization(), attemptRequest, cancellationToken);
+        }
+
+        public Task<AddressDocumentVerificationAttemptsResponse> GetAddressDocumentVerificationAttempts(string addressDocumentVerificationId, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+            return ApiClient.Get<AddressDocumentVerificationAttemptsResponse>(BuildPath(AddressDocumentVerificationsPath, addressDocumentVerificationId, AttemptsPath),
+                SdkAuthorization(), cancellationToken);
+        }
+
+        public Task<AddressDocumentVerificationAttemptResponse> GetAddressDocumentVerificationAttempt(string addressDocumentVerificationId, string attemptId, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+            CheckoutUtils.ValidateParams("attemptId", attemptId);
+            return ApiClient.Get<AddressDocumentVerificationAttemptResponse>(BuildPath(AddressDocumentVerificationsPath, addressDocumentVerificationId, AttemptsPath, attemptId),
+                SdkAuthorization(), cancellationToken);
+        }
+
+        public Task<AddressDocumentVerificationReportResponse> GetAddressDocumentVerificationReport(string addressDocumentVerificationId, CancellationToken cancellationToken = default)
+        {
+            CheckoutUtils.ValidateParams("addressDocumentVerificationId", addressDocumentVerificationId);
+            return ApiClient.Get<AddressDocumentVerificationReportResponse>(BuildPath(AddressDocumentVerificationsPath, addressDocumentVerificationId, ReportPath),
+                SdkAuthorization(), cancellationToken);
+        }
+    }
+}

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/IAddressDocumentVerificationClient.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/IAddressDocumentVerificationClient.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Checkout.Identities.AddressDocumentVerification.Requests;
+using Checkout.Identities.AddressDocumentVerification.Responses;
+
+namespace Checkout.Identities.AddressDocumentVerification
+{
+    /// <summary>
+    ///     Client for managing address document verifications in identity verification processes
+    /// </summary>
+    public interface IAddressDocumentVerificationClient
+    {
+        /// <summary>
+        ///     Creates a new address document verification
+        /// </summary>
+        Task<AddressDocumentVerificationResponse> CreateAddressDocumentVerification(AddressDocumentVerificationRequest addressDocumentVerificationRequest, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Retrieves an existing address document verification by ID
+        /// </summary>
+        Task<AddressDocumentVerificationResponse> GetAddressDocumentVerification(string addressDocumentVerificationId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Anonymizes an address document verification by removing personal data
+        /// </summary>
+        Task<AddressDocumentVerificationResponse> AnonymizeAddressDocumentVerification(string addressDocumentVerificationId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Creates a new address document verification attempt
+        /// </summary>
+        Task<AddressDocumentVerificationAttemptResponse> CreateAddressDocumentVerificationAttempt(string addressDocumentVerificationId, AddressDocumentVerificationAttemptRequest attemptRequest, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Retrieves all attempts for an address document verification
+        /// </summary>
+        Task<AddressDocumentVerificationAttemptsResponse> GetAddressDocumentVerificationAttempts(string addressDocumentVerificationId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Retrieves a specific attempt for an address document verification
+        /// </summary>
+        Task<AddressDocumentVerificationAttemptResponse> GetAddressDocumentVerificationAttempt(string addressDocumentVerificationId, string attemptId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Retrieves the PDF report for an address document verification
+        /// </summary>
+        Task<AddressDocumentVerificationReportResponse> GetAddressDocumentVerificationReport(string addressDocumentVerificationId, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationAttemptRequest.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationAttemptRequest.cs
@@ -1,0 +1,12 @@
+namespace Checkout.Identities.AddressDocumentVerification.Requests
+{
+    public class AddressDocumentVerificationAttemptRequest
+    {
+        /// <summary>
+        /// The address document image to upload
+        /// [Required]
+        /// Format: binary
+        /// </summary>
+        public string Document { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationRequest.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/Requests/AddressDocumentVerificationRequest.cs
@@ -1,0 +1,26 @@
+using Checkout.Identities.Entities;
+
+namespace Checkout.Identities.AddressDocumentVerification.Requests
+{
+    public class AddressDocumentVerificationRequest
+    {
+        /// <summary>
+        /// The applicant's unique identifier
+        /// [Required]
+        /// Pattern: ^aplt_\w+$
+        /// </summary>
+        public string ApplicantId { get; set; }
+
+        /// <summary>
+        /// Your configuration ID
+        /// [Required]
+        /// Pattern: ^usj_[a-z2-7]{26}$
+        /// </summary>
+        public string UserJourneyId { get; set; }
+
+        /// <summary>
+        /// The personal details provided by the applicant
+        /// </summary>
+        public DeclaredData DeclaredData { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationAttemptResponse.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationAttemptResponse.cs
@@ -1,0 +1,9 @@
+using Checkout.Identities.Entities;
+using Checkout.Identities.Entities.Responses;
+
+namespace Checkout.Identities.AddressDocumentVerification.Responses
+{
+    public class AddressDocumentVerificationAttemptResponse : BaseAttemptResponse<AddressDocumentVerificationAttemptStatus>
+    {
+    }
+}

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationAttemptsResponse.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationAttemptsResponse.cs
@@ -1,0 +1,8 @@
+using Checkout.Identities.Entities.Responses;
+
+namespace Checkout.Identities.AddressDocumentVerification.Responses
+{
+    public class AddressDocumentVerificationAttemptsResponse : BaseAttemptsResponse<AddressDocumentVerificationAttemptResponse>
+    {
+    }
+}

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationReportResponse.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationReportResponse.cs
@@ -1,0 +1,8 @@
+using Checkout.Identities.Entities.Responses;
+
+namespace Checkout.Identities.AddressDocumentVerification.Responses
+{
+    public class AddressDocumentVerificationReportResponse : BaseReportResponse
+    {
+    }
+}

--- a/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationResponse.cs
+++ b/src/CheckoutSdk/Identities/AddressDocumentVerification/Responses/AddressDocumentVerificationResponse.cs
@@ -1,0 +1,18 @@
+using Checkout.Identities.Entities;
+using Checkout.Identities.Entities.Responses;
+
+namespace Checkout.Identities.AddressDocumentVerification.Responses
+{
+    public class AddressDocumentVerificationResponse : BaseVerificationResponse<AddressDocumentVerificationStatus>
+    {
+        /// <summary>
+        /// The personal details provided by the applicant
+        /// </summary>
+        public DeclaredData DeclaredData { get; set; }
+
+        /// <summary>
+        /// The result of the address document check
+        /// </summary>
+        public AddressDocumentResult AddressDocument { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Identities/Entities/AddressDocumentResult.cs
+++ b/src/CheckoutSdk/Identities/Entities/AddressDocumentResult.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Checkout.Identities.Entities
+{
+    /// <summary>
+    /// The result of the address document check.
+    /// </summary>
+    public class AddressDocumentResult
+    {
+        /// <summary>
+        /// The type of address document submitted.
+        /// </summary>
+        public string DocumentType { get; set; }
+
+        /// <summary>
+        /// The issuer of the address document.
+        /// </summary>
+        public string Issuer { get; set; }
+
+        /// <summary>
+        /// The full names of the people named on the document.
+        /// </summary>
+        public List<string> FullNames { get; set; }
+
+        /// <summary>
+        /// The date the document was issued. (Format: date, yyyy-MM-dd)
+        /// </summary>
+        public string IssueDate { get; set; }
+
+        /// <summary>
+        /// The address extracted from the document.
+        /// </summary>
+        public AdvAddress Address { get; set; }
+    }
+}

--- a/src/CheckoutSdk/Identities/Entities/AddressDocumentVerificationAttemptStatus.cs
+++ b/src/CheckoutSdk/Identities/Entities/AddressDocumentVerificationAttemptStatus.cs
@@ -1,0 +1,25 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Identities.Entities
+{
+    public enum AddressDocumentVerificationAttemptStatus
+    {
+        [EnumMember(Value = "checks_in_progress")]
+        ChecksInProgress,
+
+        [EnumMember(Value = "checks_inconclusive")]
+        ChecksInconclusive,
+
+        [EnumMember(Value = "completed")]
+        Completed,
+
+        [EnumMember(Value = "quality_checks_aborted")]
+        QualityChecksAborted,
+
+        [EnumMember(Value = "quality_checks_in_progress")]
+        QualityChecksInProgress,
+
+        [EnumMember(Value = "terminated")]
+        Terminated
+    }
+}

--- a/src/CheckoutSdk/Identities/Entities/AddressDocumentVerificationStatus.cs
+++ b/src/CheckoutSdk/Identities/Entities/AddressDocumentVerificationStatus.cs
@@ -1,0 +1,28 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Identities.Entities
+{
+    public enum AddressDocumentVerificationStatus
+    {
+        [EnumMember(Value = "created")]
+        Created,
+
+        [EnumMember(Value = "quality_checks_in_progress")]
+        QualityChecksInProgress,
+
+        [EnumMember(Value = "checks_in_progress")]
+        ChecksInProgress,
+
+        [EnumMember(Value = "approved")]
+        Approved,
+
+        [EnumMember(Value = "declined")]
+        Declined,
+
+        [EnumMember(Value = "retry_required")]
+        RetryRequired,
+
+        [EnumMember(Value = "inconclusive")]
+        Inconclusive
+    }
+}

--- a/src/CheckoutSdk/Identities/Entities/AdvAddress.cs
+++ b/src/CheckoutSdk/Identities/Entities/AdvAddress.cs
@@ -1,0 +1,38 @@
+namespace Checkout.Identities.Entities
+{
+    /// <summary>
+    /// The address extracted from the document.
+    /// </summary>
+    public class AdvAddress
+    {
+        /// <summary>
+        /// The first line of the address. (max 250 characters)
+        /// </summary>
+        public string AddressLine1 { get; set; }
+
+        /// <summary>
+        /// The second line of the address. (max 250 characters)
+        /// </summary>
+        public string AddressLine2 { get; set; }
+
+        /// <summary>
+        /// The city or town. (max 50 characters)
+        /// </summary>
+        public string City { get; set; }
+
+        /// <summary>
+        /// The state, county, or province. (max 50 characters)
+        /// </summary>
+        public string State { get; set; }
+
+        /// <summary>
+        /// The postal or ZIP code. (max 50 characters)
+        /// </summary>
+        public string Zip { get; set; }
+
+        /// <summary>
+        /// The two-letter ISO country code of the address. (max 2 characters)
+        /// </summary>
+        public string Country { get; set; }
+    }
+}

--- a/test/CheckoutSdkTest/Identities/AddressDocumentVerification/AddressDocumentVerificationClientTest.cs
+++ b/test/CheckoutSdkTest/Identities/AddressDocumentVerification/AddressDocumentVerificationClientTest.cs
@@ -1,0 +1,151 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Checkout.Identities.AddressDocumentVerification.Requests;
+using Checkout.Identities.AddressDocumentVerification.Responses;
+using Checkout.Identities.Entities;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.Identities.AddressDocumentVerification
+{
+    public class AddressDocumentVerificationClientTest : UnitTestFixture
+    {
+        private const string AddressDocumentVerificationsPath = "address-document-verifications";
+        private const string AddressDocumentVerificationId = "adv_tkoi5db4hryu5cei5vwoabr7we";
+        private const string AttemptId = "adva_tkoi5db4hryu5cei5vwoabr7we";
+
+        private readonly SdkAuthorization _authorization = new SdkAuthorization(PlatformType.Default, ValidDefaultSk);
+        private readonly Mock<IApiClient> _apiClient = new Mock<IApiClient>();
+        private readonly Mock<SdkCredentials> _sdkCredentials = new Mock<SdkCredentials>(PlatformType.Default);
+        private readonly Mock<IHttpClientFactory> _httpClientFactory = new Mock<IHttpClientFactory>();
+        private readonly Mock<CheckoutConfiguration> _configuration;
+
+        public AddressDocumentVerificationClientTest()
+        {
+            _sdkCredentials.Setup(credentials => credentials.GetSdkAuthorization(SdkAuthorizationType.SecretKeyOrOAuth))
+                .Returns(_authorization);
+
+            _configuration = new Mock<CheckoutConfiguration>(_sdkCredentials.Object,
+                Environment.Sandbox, _httpClientFactory.Object);
+        }
+
+        private IAddressDocumentVerificationClient Client() =>
+            new AddressDocumentVerificationClient(_apiClient.Object, _configuration.Object);
+
+        [Fact]
+        public async Task CreateAddressDocumentVerification_Should_Call_ApiClient_Post()
+        {
+            var request = new AddressDocumentVerificationRequest
+            {
+                ApplicantId = "aplt_tkoi5db4hryu5cei5vwoabr7we",
+                UserJourneyId = "usj_tkoi5db4hryu5cei5vwoabr7we",
+                DeclaredData = new DeclaredData { Name = "Hannah Bret" }
+            };
+            var response = new AddressDocumentVerificationResponse();
+
+            _apiClient.Setup(apiClient =>
+                    apiClient.Post<AddressDocumentVerificationResponse>(
+                        AddressDocumentVerificationsPath, _authorization, request, CancellationToken.None, null))
+                .ReturnsAsync(response);
+
+            var result = await Client().CreateAddressDocumentVerification(request, CancellationToken.None);
+
+            result.ShouldNotBeNull();
+            result.ShouldBeSameAs(response);
+        }
+
+        [Fact]
+        public async Task GetAddressDocumentVerification_Should_Call_ApiClient_Get()
+        {
+            var response = new AddressDocumentVerificationResponse();
+            _apiClient.Setup(apiClient =>
+                    apiClient.Get<AddressDocumentVerificationResponse>(
+                        AddressDocumentVerificationsPath + "/" + AddressDocumentVerificationId,
+                        _authorization, CancellationToken.None))
+                .ReturnsAsync(response);
+
+            var result = await Client().GetAddressDocumentVerification(AddressDocumentVerificationId, CancellationToken.None);
+
+            result.ShouldBeSameAs(response);
+        }
+
+        [Fact]
+        public async Task AnonymizeAddressDocumentVerification_Should_Call_ApiClient_Post()
+        {
+            var response = new AddressDocumentVerificationResponse();
+            _apiClient.Setup(apiClient =>
+                    apiClient.Post<AddressDocumentVerificationResponse>(
+                        AddressDocumentVerificationsPath + "/" + AddressDocumentVerificationId + "/anonymize",
+                        _authorization, (object)null, CancellationToken.None, null))
+                .ReturnsAsync(response);
+
+            var result = await Client().AnonymizeAddressDocumentVerification(AddressDocumentVerificationId, CancellationToken.None);
+
+            result.ShouldBeSameAs(response);
+        }
+
+        [Fact]
+        public async Task CreateAttempt_Should_Call_ApiClient_Post()
+        {
+            var request = new AddressDocumentVerificationAttemptRequest { Document = "base64-data" };
+            var response = new AddressDocumentVerificationAttemptResponse();
+            _apiClient.Setup(apiClient =>
+                    apiClient.Post<AddressDocumentVerificationAttemptResponse>(
+                        AddressDocumentVerificationsPath + "/" + AddressDocumentVerificationId + "/attempts",
+                        _authorization, request, CancellationToken.None, null))
+                .ReturnsAsync(response);
+
+            var result = await Client().CreateAddressDocumentVerificationAttempt(
+                AddressDocumentVerificationId, request, CancellationToken.None);
+
+            result.ShouldBeSameAs(response);
+        }
+
+        [Fact]
+        public async Task GetAttempts_Should_Call_ApiClient_Get()
+        {
+            var response = new AddressDocumentVerificationAttemptsResponse();
+            _apiClient.Setup(apiClient =>
+                    apiClient.Get<AddressDocumentVerificationAttemptsResponse>(
+                        AddressDocumentVerificationsPath + "/" + AddressDocumentVerificationId + "/attempts",
+                        _authorization, CancellationToken.None))
+                .ReturnsAsync(response);
+
+            var result = await Client().GetAddressDocumentVerificationAttempts(AddressDocumentVerificationId, CancellationToken.None);
+
+            result.ShouldBeSameAs(response);
+        }
+
+        [Fact]
+        public async Task GetAttempt_Should_Call_ApiClient_Get()
+        {
+            var response = new AddressDocumentVerificationAttemptResponse();
+            _apiClient.Setup(apiClient =>
+                    apiClient.Get<AddressDocumentVerificationAttemptResponse>(
+                        AddressDocumentVerificationsPath + "/" + AddressDocumentVerificationId + "/attempts/" + AttemptId,
+                        _authorization, CancellationToken.None))
+                .ReturnsAsync(response);
+
+            var result = await Client().GetAddressDocumentVerificationAttempt(
+                AddressDocumentVerificationId, AttemptId, CancellationToken.None);
+
+            result.ShouldBeSameAs(response);
+        }
+
+        [Fact]
+        public async Task GetReport_Should_Call_ApiClient_Get()
+        {
+            var response = new AddressDocumentVerificationReportResponse();
+            _apiClient.Setup(apiClient =>
+                    apiClient.Get<AddressDocumentVerificationReportResponse>(
+                        AddressDocumentVerificationsPath + "/" + AddressDocumentVerificationId + "/pdf-report",
+                        _authorization, CancellationToken.None))
+                .ReturnsAsync(response);
+
+            var result = await Client().GetAddressDocumentVerificationReport(AddressDocumentVerificationId, CancellationToken.None);
+
+            result.ShouldBeSameAs(response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the new **Address Document Verification (Adv)** API family introduced in the Checkout.com swagger on 2026-07-16 (INT-1665). This mirrors the existing ID Document Verification client and reuses the `identity-verification` OAuth scope (no new scope).

## Changes

New `AddressDocumentVerification` client exposing the 7 endpoints, plus request/response models and status enums, wired into the SDK entry point next to `IdDocumentVerification`:

- `POST /address-document-verifications` — create
- `GET  /address-document-verifications/{id}` — retrieve
- `POST /address-document-verifications/{id}/anonymize` — anonymize
- `POST /address-document-verifications/{id}/attempts` — create attempt
- `GET  /address-document-verifications/{id}/attempts` — list attempts
- `GET  /address-document-verifications/{id}/attempts/{attemptId}` — get attempt
- `GET  /address-document-verifications/{id}/pdf-report` — PDF report

Request model: `applicant_id`, `user_journey_id`, `declared_data`. Attempt request: `document`. Responses cover `AdvVerificationStatuses` / `AdvAttemptStates`, `response_codes`, `_links` and the extracted `address_document` result.

## API Reference

Swagger schemas: `AdvAddressDocumentVerification*`, `AdvAttempt*`, `AdvAddress`, `AdvAddressDocumentResult`, `AdvVerificationStatuses`, `AdvAttemptStates`.

## Tests

Unit tests covering all 7 endpoints; integration tests scaffolded (skipped, require sandbox entitlement). Build + tests green locally.
