### PR TITLE
feature/INT-1670 - CardType and CardCategory enum fixes

### DIFF
--- a/src/CheckoutSdk/Authentication/Standalone/Common/AccountInfo/CardholderAccountAgeIndicatorType.cs
+++ b/src/CheckoutSdk/Authentication/Standalone/Common/AccountInfo/CardholderAccountAgeIndicatorType.cs
@@ -4,7 +4,7 @@ namespace Checkout.Authentication.Standalone.Common.AccountInfo
 {
     public enum CardholderAccountAgeIndicatorType
     {
-        [EnumMember(Value = "no_account,")]
+        [EnumMember(Value = "no_account")]
         NoAccount,
 
         [EnumMember(Value = "this_transaction")]

--- a/src/CheckoutSdk/Common/CardCategory.cs
+++ b/src/CheckoutSdk/Common/CardCategory.cs
@@ -1,13 +1,19 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace Checkout.Common
 {
     public enum CardCategory
     {
-        [EnumMember(Value = "all")] All,
-        [EnumMember(Value = "commercial")] Commercial,
-        [EnumMember(Value = "consumer")] Consumer,
-        [EnumMember(Value = "NotSet")] NotSet,
-        [EnumMember(Value = "other")] Other
+        [EnumMember(Value = "commercial")]
+        Commercial,
+
+        [EnumMember(Value = "consumer")]
+        Consumer,
+
+        /// <summary>
+        /// Returned only on card payout destinations.
+        /// </summary>
+        [EnumMember(Value = "unknown")]
+        Unknown
     }
 }

--- a/src/CheckoutSdk/Common/CardType.cs
+++ b/src/CheckoutSdk/Common/CardType.cs
@@ -1,13 +1,28 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace Checkout.Common
 {
     public enum CardType
     {
-        [EnumMember(Value = "Credit")] Credit,
-        [EnumMember(Value = "Debit")] Debit,
-        [EnumMember(Value = "Prepaid")] Prepaid,
-        [EnumMember(Value = "Charge")] Charge,
-        [EnumMember(Value = "Deferred Debit")] DeferredDebit
+        [EnumMember(Value = "Credit")]
+        Credit,
+
+        [EnumMember(Value = "Debit")]
+        Debit,
+
+        [EnumMember(Value = "Prepaid")]
+        Prepaid,
+
+        [EnumMember(Value = "Charge")]
+        Charge,
+
+        [EnumMember(Value = "Deferred Debit")]
+        DeferredDebit,
+
+        /// <summary>
+        /// Returned only on card payout destinations.
+        /// </summary>
+        [EnumMember(Value = "Unknown")]
+        Unknown
     }
 }

--- a/src/CheckoutSdk/Metadata/Card/CardMetadataType.cs
+++ b/src/CheckoutSdk/Metadata/Card/CardMetadataType.cs
@@ -21,7 +21,11 @@ namespace Checkout.Metadata.Card
         Charge,
 
         /// <summary>Deferred debit card.</summary>
-        [EnumMember(Value = "deferred_debit")]
+        [EnumMember(Value = "deferred debit")]
         DeferredDebit,
+
+        /// <summary>Network token.</summary>
+        [EnumMember(Value = "network token")]
+        NetworkToken,
     }
 }

--- a/test/CheckoutSdkTest/JsonSerializerTest.cs
+++ b/test/CheckoutSdkTest/JsonSerializerTest.cs
@@ -302,16 +302,16 @@ namespace Checkout
         }
 
         [Fact]
-        public void ShouldReturnNullForUnknownCardTypeEnumValue()
+        public void ShouldReturnNullForUnrecognizedCardTypeEnumValue()
         {
-            const string json = @"{""type"":""card"",""card_type"":""UNKNOWN""}";
+            const string json = @"{""type"":""card"",""card_type"":""NOT_A_CARD_TYPE""}";
             var source = (CardResponseSource)new JsonSerializer().Deserialize(json, typeof(CardResponseSource));
             source.ShouldNotBeNull();
             source.CardType.ShouldBeNull();
         }
 
         [Fact]
-        public void ShouldDeserializeFullPaymentResponseWithUnknownCardType()
+        public void ShouldDeserializeFullPaymentResponseWithUnrecognizedCardType()
         {
             const string json = @"{
                 ""id"": ""pay_talabat_incident"",
@@ -320,7 +320,7 @@ namespace Checkout
                 ""source"": {
                     ""type"": ""card"",
                     ""last4"": ""4242"",
-                    ""card_type"": ""UNKNOWN""
+                    ""card_type"": ""NOT_A_CARD_TYPE""
                 }
             }";
 
@@ -331,6 +331,16 @@ namespace Checkout
             response.Approved.ShouldBe(true);
             var source = response.Source.ShouldBeAssignableTo<CardResponseSource>();
             source.CardType.ShouldBeNull();
+        }
+
+        [Fact]
+        public void ShouldDeserializeUnknownCardTypeAndCardCategory()
+        {
+            // UNKNOWN is a real value on card payout destinations, not an unrecognized one.
+            const string json = @"{""type"":""card"",""card_type"":""UNKNOWN"",""card_category"":""UNKNOWN""}";
+            var source = (CardResponseSource)new JsonSerializer().Deserialize(json, typeof(CardResponseSource));
+            source.CardType.ShouldBe(CardType.Unknown);
+            source.CardCategory.ShouldBe(CardCategory.Unknown);
         }
 
     }

--- a/test/CheckoutSdkTest/Metadata/CardMetadataResponseSerializationTest.cs
+++ b/test/CheckoutSdkTest/Metadata/CardMetadataResponseSerializationTest.cs
@@ -77,6 +77,48 @@ namespace Checkout.Metadata
         // ── Response deserialization ───────────────────────────────────────────
 
         [Fact]
+        public void ShouldDeserializeEveryCardTypeValue()
+        {
+            var expected = new Dictionary<string, CardMetadataType>
+            {
+                { "CREDIT", CardMetadataType.Credit },
+                { "DEBIT", CardMetadataType.Debit },
+                { "PREPAID", CardMetadataType.Prepaid },
+                { "CHARGE", CardMetadataType.Charge },
+                { "DEFERRED DEBIT", CardMetadataType.DeferredDebit },
+                { "NETWORK TOKEN", CardMetadataType.NetworkToken }
+            };
+
+            foreach (var pair in expected)
+            {
+                var json = @"{""bin"":""45434720"",""card_type"":""" + pair.Key + @"""}";
+                var r = (CardMetadataResponse)Serializer.Deserialize(json, typeof(CardMetadataResponse));
+                r.CardType.ShouldBe(pair.Value, $"card_type '{pair.Key}' did not deserialize");
+            }
+        }
+
+        [Fact]
+        public void ShouldDeserializeEveryCardCategoryValue()
+        {
+            // CONSUMER and COMMERCIAL are the values this endpoint returns. UNKNOWN is covered
+            // too because CardCategory is the shared Common enum, and card payout destinations
+            // return it.
+            var expected = new Dictionary<string, CardCategory>
+            {
+                { "CONSUMER", CardCategory.Consumer },
+                { "COMMERCIAL", CardCategory.Commercial },
+                { "UNKNOWN", CardCategory.Unknown }
+            };
+
+            foreach (var pair in expected)
+            {
+                var json = @"{""bin"":""45434720"",""card_category"":""" + pair.Key + @"""}";
+                var r = (CardMetadataResponse)Serializer.Deserialize(json, typeof(CardMetadataResponse));
+                r.CardCategory.ShouldBe(pair.Value, $"card_category '{pair.Key}' did not deserialize");
+            }
+        }
+
+        [Fact]
         public void ShouldDeserializeFullResponse()
         {
             const string json = @"{


### PR DESCRIPTION
This pull request updates and improves the handling of card type and card category enum values across the SDK, especially focusing on supporting new and special values returned by the API. It also enhances test coverage to ensure all possible enum values are correctly serialized and deserialized, and clarifies the difference between unrecognized and "unknown" enum values.

**Enum value updates and additions:**

* Added `Unknown` value to both `CardType` and `CardCategory` enums, with comments clarifying that these are returned only on card payout destinations. [[1]](diffhunk://#diff-7b4279b91ec7795fe0ba5802c985e38020271583838663cb436d5a3c69625446L1-R26) [[2]](diffhunk://#diff-5020aec2c14eb8e58ecaffd9e9ea82db976bb5b42f950181c3d3882bd40d08c8L1-R17)
* Added `NetworkToken` to the `CardMetadataType` enum and fixed the `DeferredDebit` value to match the expected API string.

**Test improvements:**

* Expanded unit tests to verify that all possible enum values (including new ones like `Unknown` and `NetworkToken`) are correctly deserialized in `CardMetadataResponse` and `CardResponseSource`. [[1]](diffhunk://#diff-2fd827a1644103fc6f57ef906500b99dcf2ef142741fc0e288debf81946af26cR79-R120) [[2]](diffhunk://#diff-b711b48a08d153ba8adc6d8b12b321dfabc8e9c0363472de0dacecf42ef3d755R336-R345)
* Improved test naming and logic to distinguish between unrecognized enum values (which should deserialize as `null`) and the recognized "UNKNOWN" value (which should map to the new `Unknown` enum member). [[1]](diffhunk://#diff-b711b48a08d153ba8adc6d8b12b321dfabc8e9c0363472de0dacecf42ef3d755L305-R314) [[2]](diffhunk://#diff-b711b48a08d153ba8adc6d8b12b321dfabc8e9c0363472de0dacecf42ef3d755L323-R323) [[3]](diffhunk://#diff-b711b48a08d153ba8adc6d8b12b321dfabc8e9c0363472de0dacecf42ef3d755R336-R345)

**Minor fixes:**

* Fixed a typo in the `CardholderAccountAgeIndicatorType` enum by removing an extra comma from the `no_account` value.