### PR TITLE
feat(payments): add ProcessingData response fields scheme, partner_fraud_status, partner_merchant_advice_code

### DIFF
--- a/src/CheckoutSdk/Payments/Response/ProcessingData.cs
+++ b/src/CheckoutSdk/Payments/Response/ProcessingData.cs
@@ -5,54 +5,161 @@ namespace Checkout.Payments.Response
 {
     public class ProcessingData
     {
+        /// <summary>
+        /// The preferred scheme for co-badged card payment processing. If performing 3DS via a third
+        /// party, set this value to the scheme that processed 3DS. This field does not support PINless
+        /// debit schemes in the US (STAR, PULSE, NYCE, ACCEL, SHAZAM).
+        /// [Optional]
+        /// </summary>
         public PreferredSchema? PreferredScheme { get; set; }
-        
+
+        /// <summary>
+        /// The customer's application identifier.
+        /// [Optional]
+        /// </summary>
         public string AppId { get; set; }
-        
+
+        /// <summary>
+        /// The customer's ID on the partner platform.
+        /// [Optional]
+        /// </summary>
         public string PartnerCustomerId { get; set; }
-        
+
+        /// <summary>
+        /// The partner-originated unique payment identifier.
+        /// [Optional]
+        /// </summary>
         public string PartnerPaymentId { get; set; }
-        
+
+        /// <summary>
+        /// Total tax amount of the order.
+        /// [Optional]
+        /// </summary>
         public long? TaxAmount { get; set; }
-        
+
+        /// <summary>
+        /// The country where the purchase was made.
+        /// Not documented in the public spec for this response, kept for backward compatibility.
+        /// [Optional]
+        /// </summary>
         public CountryCode? PurchaseCountry { get; set; }
-        
+
+        /// <summary>
+        /// The language and region of the customer. ISO 639-2 language code, its value consists of
+        /// language-country.
+        /// [Optional]
+        /// ^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}))?$
+        /// &gt;= 2 characters, &lt;= 10 characters
+        /// </summary>
         public string Locale { get; set; }
-        
+
+        /// <summary>
+        /// A unique identifier for the authorization provided by partner.
+        /// [Optional]
+        /// </summary>
         public string RetrievalReferenceNumber { get; set; }
-        
+
+        /// <summary>
+        /// The Klarna order ID associated with the payment.
+        /// [Optional]
+        /// </summary>
         public string PartnerOrderId { get; set; }
-        
+
+        /// <summary>
+        /// Status of a payment provided by partner.
+        /// [Optional]
+        /// </summary>
         public string PartnerStatus { get; set; }
-        
+
+        /// <summary>
+        /// Unique transaction identification provided by partner.
+        /// [Optional]
+        /// </summary>
         public string PartnerTransactionId { get; set; }
-        
+
+        /// <summary>
+        /// The list of error codes that led the payment to fail or be declined, as given by the
+        /// payment provider.
+        /// [Optional]
+        /// </summary>
         public IList<string> PartnerErrorCodes { get; set; }
-        
+
+        /// <summary>
+        /// Error description provided by partner.
+        /// [Optional]
+        /// </summary>
         public string PartnerErrorMessage { get; set; }
-        
+
+        /// <summary>
+        /// Authorization code provided by partner.
+        /// [Optional]
+        /// </summary>
         public string PartnerAuthorizationCode { get; set; }
-        
+
+        /// <summary>
+        /// Authorization response code provided by partner.
+        /// [Optional]
+        /// </summary>
         public string PartnerAuthorizationResponseCode { get; set; }
-        
+
+        /// <summary>
+        /// Fraud status of the payment.
+        /// Not documented in the public spec for this response, kept for backward compatibility.
+        /// Prefer <see cref="PartnerFraudStatus"/>.
+        /// [Optional]
+        /// </summary>
         public string FraudStatus { get; set; }
-        
+
+        /// <summary>
+        /// The payment method authorized by the provider.
+        /// Not documented in the public spec for this response, kept for backward compatibility.
+        /// [Optional]
+        /// </summary>
         public ProviderAuthorizedPaymentMethod ProviderAuthorizedPaymentMethod { get; set; }
-        
+
+        /// <summary>
+        /// An array defining which of the configured payment options within a payment category
+        /// (for example, pay_later or pay_over_time) should be displayed for this purchase.
+        /// [Optional]
+        /// </summary>
         public IList<string> CustomPaymentMethodIds { get; set; }
 
+        /// <summary>
+        /// Indicates whether the payment is an Account Funding Transaction.
+        /// [Optional]
+        /// </summary>
         public bool? Aft { get; set; }
-        
+
+        /// <summary>
+        /// Four-digit code for retail financial services expressed in ISO 18245 format, classifying
+        /// the types of goods or services you provide.
+        /// [Optional]
+        /// </summary>
         public string MerchantCategoryCode { get; set; }
-        
+
+        /// <summary>
+        /// The merchant identifier that was configured with the scheme and used for the payment.
+        /// [Optional]
+        /// </summary>
         public string SchemeMerchantId { get; set; }
-        
+
+        /// <summary>
+        /// The type of Primary Account Number (PAN) used for the payment. DPAN indicates network
+        /// token was used, FPAN indicates the full card was used.
+        /// [Optional]
+        /// </summary>
         public PanProcessedType? PanTypeProcessed { get; set; }
-        
+
+        /// <summary>
+        /// The flag indicating if Checkout Network Token was available for the payment.
+        /// Not documented in the public spec for this response, kept for backward compatibility.
+        /// [Optional]
+        /// </summary>
         public bool? CkoNetworkTokenAvailable { get; set; }
 
         /// <summary>
         /// Indicates whether the fallback_source field was used for the payment.
+        /// [Optional]
         /// </summary>
         public bool? FallbackSourceUsed { get; set; }
 
@@ -77,6 +184,41 @@ namespace Checkout.Payments.Response
         /// [Optional]
         /// </summary>
         public string PartnerResponseCode { get; set; }
+
+        /// <summary>
+        /// The scheme on which the payment was authorized. This may differ from the card's scheme used
+        /// for the payment if the card is co-badged and the payment was authorized on a different network.
+        /// [Optional] readOnly
+        /// </summary>
+        public string Scheme { get; set; }
+
+        /// <summary>
+        /// Partner fraud status. If the status is Pending, and the merchant captures before it changes
+        /// to Accepted, the risk of the transaction is solely on the merchant.
+        /// [Optional]
+        /// </summary>
+        public string PartnerFraudStatus { get; set; }
+
+        /// <summary>
+        /// The Mastercard Merchant Advice Code (MAC), which contains additional information about the
+        /// transaction. For example, the MAC can inform you if the transaction was performed using a
+        /// consumer non-reloadable prepaid card or a consumer single-use virtual card. For declined
+        /// transactions, the MAC also indicates whether the payment can be retried and how long to wait.
+        /// [Optional]
+        /// </summary>
+        public string PartnerMerchantAdviceCode { get; set; }
+
+        /// <summary>
+        /// Contains information about the accommodation booked by the customer.
+        /// [Optional]
+        /// </summary>
+        public IList<AccommodationData> AccommodationData { get; set; }
+
+        /// <summary>
+        /// Contains information about the airline ticket and flights booked by the customer.
+        /// [Optional]
+        /// </summary>
+        public IList<AirlineData> AirlineData { get; set; }
 
         /// <summary>
         /// The scheme transaction link identifier. Returned for Mastercard transactions when the scheme

--- a/test/CheckoutSdkTest/Payments/ProcessingDataSerializationTest.cs
+++ b/test/CheckoutSdkTest/Payments/ProcessingDataSerializationTest.cs
@@ -1,6 +1,7 @@
 using Checkout.Common;
 using Checkout.Payments.Response;
 using Shouldly;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -9,6 +10,75 @@ namespace Checkout.Payments
     public class ProcessingDataSerializationTest
     {
         private static readonly JsonSerializer Serializer = new JsonSerializer();
+
+        private static ProcessingData CreateFullyPopulated()
+        {
+            return new ProcessingData
+            {
+                PreferredScheme = PreferredSchema.Visa,
+                AppId = "com.iap.linker_portal",
+                PartnerCustomerId = "2102209000001106125F8",
+                PartnerPaymentId = "440644309099499894406",
+                TaxAmount = 1000L,
+                PurchaseCountry = CountryCode.GB,
+                Locale = "en-US",
+                RetrievalReferenceNumber = "909913440644",
+                PartnerOrderId = "ord_abc",
+                PartnerStatus = "pending",
+                PartnerTransactionId = "txn_abc",
+                PartnerErrorCodes = new List<string> { "ERR_001", "ERR_002" },
+                PartnerErrorMessage = "Payment declined",
+                PartnerAuthorizationCode = "auth_123",
+                PartnerAuthorizationResponseCode = "00",
+                FraudStatus = "approved",
+                ProviderAuthorizedPaymentMethod = new ProviderAuthorizedPaymentMethod
+                {
+                    Type = "pay_later",
+                    Description = "Pay in 30 days",
+                    NumberOfInstallments = 3L,
+                    NumberOfDays = 30L
+                },
+                CustomPaymentMethodIds = new List<string> { "cpm_001" },
+                Aft = true,
+                MerchantCategoryCode = "5311",
+                SchemeMerchantId = "123456",
+                PanTypeProcessed = PanProcessedType.FPAN,
+                CkoNetworkTokenAvailable = true,
+                FallbackSourceUsed = false,
+                FailureCode = "partner_error",
+                PartnerCode = "999111",
+                PartnerResponseCode = "ER_WRONG_TICKET",
+                Scheme = "ACCEL",
+                PartnerFraudStatus = "Pending",
+                PartnerMerchantAdviceCode = "24",
+                AccommodationData = new List<AccommodationData>
+                {
+                    new AccommodationData
+                    {
+                        Name = "Hotel California",
+                        BookingReference = "BR-001",
+                        CheckInDate = DateTime.Parse("2026-08-01"),
+                        CheckOutDate = DateTime.Parse("2026-08-05"),
+                        City = "London",
+                        Country = CountryCode.GB,
+                        NumberOfRooms = 2
+                    }
+                },
+                AirlineData = new List<AirlineData>
+                {
+                    new AirlineData
+                    {
+                        Ticket = new Ticket
+                        {
+                            Number = "045-21351455",
+                            IssueDate = "2026-08-01",
+                            IssuingCarrierCode = "AA"
+                        }
+                    }
+                },
+                SchemeTransactionLinkId = "MTL-001"
+            };
+        }
 
         [Fact]
         public void ShouldSerializeWithRequiredProperties()
@@ -21,58 +91,145 @@ namespace Checkout.Payments
         [Fact]
         public void ShouldSerializeWithAllOptionalProperties()
         {
-            var data = new ProcessingData
-            {
-                PreferredScheme = PreferredSchema.Visa,
-                AppId = "app_123",
-                PartnerCustomerId = "cust_abc",
-                PartnerPaymentId = "pay_abc",
-                TaxAmount = 100L,
-                PurchaseCountry = CountryCode.GB,
-                Locale = "en-GB",
-                RetrievalReferenceNumber = "rrn_456",
-                PartnerOrderId = "ord_abc",
-                PartnerStatus = "pending",
-                PartnerTransactionId = "txn_abc",
-                PartnerErrorCodes = new List<string> { "ERR_001", "ERR_002" },
-                PartnerErrorMessage = "Payment declined",
-                PartnerAuthorizationCode = "auth_123",
-                PartnerAuthorizationResponseCode = "00",
-                FraudStatus = "approved",
-                CustomPaymentMethodIds = new List<string> { "cpm_001" },
-                Aft = true,
-                MerchantCategoryCode = "5411",
-                SchemeMerchantId = "scheme_merchant_001",
-                PanTypeProcessed = PanProcessedType.FPAN,
-                CkoNetworkTokenAvailable = true,
-                FallbackSourceUsed = false,
-                SchemeTransactionLinkId = "MTL-001"
-            };
+            var data = CreateFullyPopulated();
 
             Should.NotThrow(() => Serializer.Serialize(data));
         }
 
         [Fact]
-        public void ShouldDeserializeSchemeTransactionLinkId()
+        public void ShouldRoundTripSerializeAllProperties()
         {
-            const string json = @"{""scheme_transaction_link_id"": ""MTL-001""}";
-
-            var result = (ProcessingData)Serializer.Deserialize(json, typeof(ProcessingData));
-
-            result.ShouldNotBeNull();
-            result.SchemeTransactionLinkId.ShouldBe("MTL-001");
-        }
-
-        [Fact]
-        public void ShouldRoundTripSerializeSchemeTransactionLinkId()
-        {
-            var original = new ProcessingData { SchemeTransactionLinkId = "MTL-XYZ-789" };
+            var original = CreateFullyPopulated();
 
             var json = Serializer.Serialize(original);
             var deserialized = (ProcessingData)Serializer.Deserialize(json, typeof(ProcessingData));
 
-            json.ShouldContain("\"scheme_transaction_link_id\":\"MTL-XYZ-789\"");
-            deserialized.SchemeTransactionLinkId.ShouldBe("MTL-XYZ-789");
+            deserialized.ShouldNotBeNull();
+            deserialized.PreferredScheme.ShouldBe(original.PreferredScheme);
+            deserialized.AppId.ShouldBe(original.AppId);
+            deserialized.PartnerCustomerId.ShouldBe(original.PartnerCustomerId);
+            deserialized.PartnerPaymentId.ShouldBe(original.PartnerPaymentId);
+            deserialized.TaxAmount.ShouldBe(original.TaxAmount);
+            deserialized.PurchaseCountry.ShouldBe(original.PurchaseCountry);
+            deserialized.Locale.ShouldBe(original.Locale);
+            deserialized.RetrievalReferenceNumber.ShouldBe(original.RetrievalReferenceNumber);
+            deserialized.PartnerOrderId.ShouldBe(original.PartnerOrderId);
+            deserialized.PartnerStatus.ShouldBe(original.PartnerStatus);
+            deserialized.PartnerTransactionId.ShouldBe(original.PartnerTransactionId);
+            deserialized.PartnerErrorCodes.ShouldBe(original.PartnerErrorCodes);
+            deserialized.PartnerErrorMessage.ShouldBe(original.PartnerErrorMessage);
+            deserialized.PartnerAuthorizationCode.ShouldBe(original.PartnerAuthorizationCode);
+            deserialized.PartnerAuthorizationResponseCode.ShouldBe(original.PartnerAuthorizationResponseCode);
+            deserialized.FraudStatus.ShouldBe(original.FraudStatus);
+            deserialized.ProviderAuthorizedPaymentMethod.Type.ShouldBe("pay_later");
+            deserialized.ProviderAuthorizedPaymentMethod.Description.ShouldBe("Pay in 30 days");
+            deserialized.ProviderAuthorizedPaymentMethod.NumberOfInstallments.ShouldBe(3L);
+            deserialized.ProviderAuthorizedPaymentMethod.NumberOfDays.ShouldBe(30L);
+            deserialized.CustomPaymentMethodIds.ShouldBe(original.CustomPaymentMethodIds);
+            deserialized.Aft.ShouldBe(original.Aft);
+            deserialized.MerchantCategoryCode.ShouldBe(original.MerchantCategoryCode);
+            deserialized.SchemeMerchantId.ShouldBe(original.SchemeMerchantId);
+            deserialized.PanTypeProcessed.ShouldBe(original.PanTypeProcessed);
+            deserialized.CkoNetworkTokenAvailable.ShouldBe(original.CkoNetworkTokenAvailable);
+            deserialized.FallbackSourceUsed.ShouldBe(original.FallbackSourceUsed);
+            deserialized.FailureCode.ShouldBe(original.FailureCode);
+            deserialized.PartnerCode.ShouldBe(original.PartnerCode);
+            deserialized.PartnerResponseCode.ShouldBe(original.PartnerResponseCode);
+            deserialized.Scheme.ShouldBe(original.Scheme);
+            deserialized.PartnerFraudStatus.ShouldBe(original.PartnerFraudStatus);
+            deserialized.PartnerMerchantAdviceCode.ShouldBe(original.PartnerMerchantAdviceCode);
+            deserialized.AccommodationData.Count.ShouldBe(1);
+            deserialized.AccommodationData[0].Name.ShouldBe("Hotel California");
+            deserialized.AccommodationData[0].City.ShouldBe("London");
+            deserialized.AirlineData.Count.ShouldBe(1);
+            deserialized.AirlineData[0].Ticket.Number.ShouldBe("045-21351455");
+            deserialized.SchemeTransactionLinkId.ShouldBe(original.SchemeTransactionLinkId);
+        }
+
+        [Fact]
+        public void ShouldDeserializeSwaggerExample()
+        {
+            const string json = @"{
+                ""preferred_scheme"": ""visa"",
+                ""app_id"": ""com.iap.linker_portal"",
+                ""partner_customer_id"": ""2102209000001106125F8"",
+                ""partner_payment_id"": ""440644309099499894406"",
+                ""tax_amount"": 1000,
+                ""locale"": ""en-US"",
+                ""retrieval_reference_number"": ""909913440644"",
+                ""partner_order_id"": ""ord_abc"",
+                ""partner_status"": ""pending"",
+                ""partner_transaction_id"": ""txn_abc"",
+                ""partner_error_codes"": [""ERR_001""],
+                ""partner_error_message"": ""Payment declined"",
+                ""partner_authorization_code"": ""auth_123"",
+                ""partner_authorization_response_code"": ""00"",
+                ""custom_payment_method_ids"": [""cpm_001""],
+                ""aft"": true,
+                ""merchant_category_code"": ""5311"",
+                ""scheme_merchant_id"": ""123456"",
+                ""pan_type_processed"": ""fpan"",
+                ""fallback_source_used"": false,
+                ""failure_code"": ""partner_error"",
+                ""partner_code"": ""999111"",
+                ""partner_response_code"": ""ER_WRONG_TICKET"",
+                ""scheme"": ""ACCEL"",
+                ""partner_fraud_status"": ""Pending"",
+                ""partner_merchant_advice_code"": ""24"",
+                ""scheme_transaction_link_id"": ""MTL-001""
+            }";
+
+            var result = (ProcessingData)Serializer.Deserialize(json, typeof(ProcessingData));
+
+            result.ShouldNotBeNull();
+            result.PreferredScheme.ShouldBe(PreferredSchema.Visa);
+            result.AppId.ShouldBe("com.iap.linker_portal");
+            result.PartnerCustomerId.ShouldBe("2102209000001106125F8");
+            result.PartnerPaymentId.ShouldBe("440644309099499894406");
+            result.TaxAmount.ShouldBe(1000L);
+            result.Locale.ShouldBe("en-US");
+            result.RetrievalReferenceNumber.ShouldBe("909913440644");
+            result.PartnerOrderId.ShouldBe("ord_abc");
+            result.PartnerStatus.ShouldBe("pending");
+            result.PartnerTransactionId.ShouldBe("txn_abc");
+            result.PartnerErrorCodes.ShouldBe(new List<string> { "ERR_001" });
+            result.PartnerErrorMessage.ShouldBe("Payment declined");
+            result.PartnerAuthorizationCode.ShouldBe("auth_123");
+            result.PartnerAuthorizationResponseCode.ShouldBe("00");
+            result.CustomPaymentMethodIds.ShouldBe(new List<string> { "cpm_001" });
+            result.Aft.ShouldBe(true);
+            result.MerchantCategoryCode.ShouldBe("5311");
+            result.SchemeMerchantId.ShouldBe("123456");
+            result.PanTypeProcessed.ShouldBe(PanProcessedType.FPAN);
+            result.FallbackSourceUsed.ShouldBe(false);
+            result.FailureCode.ShouldBe("partner_error");
+            result.PartnerCode.ShouldBe("999111");
+            result.PartnerResponseCode.ShouldBe("ER_WRONG_TICKET");
+            result.Scheme.ShouldBe("ACCEL");
+            result.PartnerFraudStatus.ShouldBe("Pending");
+            result.PartnerMerchantAdviceCode.ShouldBe("24");
+            result.SchemeTransactionLinkId.ShouldBe("MTL-001");
+        }
+
+        [Fact]
+        public void ShouldRoundTripSerializeSchemeAndPartnerResponseFields()
+        {
+            var original = new ProcessingData
+            {
+                Scheme = "ACCEL",
+                PartnerFraudStatus = "Accepted",
+                PartnerMerchantAdviceCode = "24"
+            };
+
+            var json = Serializer.Serialize(original);
+            var deserialized = (ProcessingData)Serializer.Deserialize(json, typeof(ProcessingData));
+
+            json.ShouldContain("\"scheme\":\"ACCEL\"");
+            json.ShouldContain("\"partner_fraud_status\":\"Accepted\"");
+            json.ShouldContain("\"partner_merchant_advice_code\":\"24\"");
+            deserialized.Scheme.ShouldBe("ACCEL");
+            deserialized.PartnerFraudStatus.ShouldBe("Accepted");
+            deserialized.PartnerMerchantAdviceCode.ShouldBe("24");
         }
 
         [Fact]
@@ -90,24 +247,6 @@ namespace Checkout.Payments
             result.FallbackSourceUsed.ShouldBe(true);
             result.AppId.ShouldBe("app_123");
             result.RetrievalReferenceNumber.ShouldBe("rrn_456");
-        }
-
-        [Fact]
-        public void ShouldRoundTripSerializeFallbackSourceUsed()
-        {
-            var original = new ProcessingData
-            {
-                FallbackSourceUsed = false,
-                AppId = "app_abc",
-                MerchantCategoryCode = "5411"
-            };
-
-            var json = Serializer.Serialize(original);
-            var deserialized = (ProcessingData)Serializer.Deserialize(json, typeof(ProcessingData));
-
-            deserialized.FallbackSourceUsed.ShouldBe(false);
-            deserialized.AppId.ShouldBe("app_abc");
-            deserialized.MerchantCategoryCode.ShouldBe("5411");
         }
     }
 }


### PR DESCRIPTION
**Summary**

Adds the three response-only fields `scheme`, `partner_fraud_status` and `partner_merchant_advice_code` to the payment `ProcessingData` response model, aligning the .NET SDK with the swagger `ProcessingData` schema returned by `GET /payments/{id}`. Java, Go and Ruby already carry them (INT-1668).

The bidirectional audit of the class also surfaced two arrays present in the spec but missing from the SDK (`accommodation_data`, `airline_data`), so they are included here.

**Changes**
- `src/CheckoutSdk/Payments/Response/ProcessingData.cs` — added `Scheme`, `PartnerFraudStatus`, `PartnerMerchantAdviceCode`, `AccommodationData` (`IList<AccommodationData>`) and `AirlineData` (`IList<AirlineData>`); completed the XML documentation of every property in the class with the swagger description and constraints
- `test/CheckoutSdkTest/Payments/ProcessingDataSerializationTest.cs` — extended coverage to all 32 properties: fully populated round-trip (including nested accommodation and airline objects), swagger-example deserialization, and a dedicated round-trip for the three new fields

**API Reference**
- `GET /payments/{id}` — `PaymentDetails.processing` (`ProcessingData` schema)

Note: `PaymentResponse.processing` (`POST /payments`) is a different inline schema and is intentionally not touched here.

**Breaking changes**

None. All additions are new optional response properties.

**README**

No impact. The README does not document individual response fields.