### PR TITLE
fix: add merchant_id to the Google Pay enrollment response

### DIFF
--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/GooglePay/Responses/GooglePayEnrollmentResponse.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/GooglePay/Responses/GooglePayEnrollmentResponse.cs
@@ -6,10 +6,21 @@ namespace Checkout.HandlePaymentsAndPayouts.GooglePay.Responses
 {
     /// <summary>
     /// Response returned after enrolling an entity with Google Pay.
-    /// Required (API): tosAcceptedTime, state.
+    /// <para>
+    /// The real 201 body is { merchant_id, tos_accepted_time, state }. The spec declares only
+    /// tosAcceptedTime and state, with additionalProperties false, so merchant_id was missing
+    /// here: the class was generated faithfully from a wrong schema. Reported by a merchant.
+    /// The spec is being fixed separately; until then this class follows the live API.
+    /// </para>
     /// </summary>
     public class GooglePayEnrollmentResponse : Resource
     {
+        /// <summary>
+        /// The Google Pay merchant identifier assigned to the entity, needed to initialise
+        /// Google Pay on the client. Returned by the API but absent from the spec.
+        /// </summary>
+        public string MerchantId { get; set; }
+
         /// <summary>
         /// An ISO 8601 timestamp of when the Google terms of service were accepted.
         /// [Required]

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/GooglePay/GooglePayEnrollmentResponseSerializationTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/GooglePay/GooglePayEnrollmentResponseSerializationTest.cs
@@ -1,0 +1,86 @@
+using Checkout.HandlePaymentsAndPayouts.GooglePay.Entities;
+using Checkout.HandlePaymentsAndPayouts.GooglePay.Responses;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.HandlePaymentsAndPayouts.GooglePay
+{
+    /// <summary>
+    /// Covers the Google Pay enrollment response against the body the API really returns.
+    /// <para>
+    /// The spec declares only tosAcceptedTime and state, with additionalProperties false, so
+    /// merchant_id was missing from the model. A merchant reported it. These tests deserialize
+    /// the real sandbox 201 body rather than the swagger example, because the swagger example is
+    /// the thing that was wrong.
+    /// </para>
+    /// </summary>
+    public class GooglePayEnrollmentResponseSerializationTest
+    {
+        private readonly JsonSerializer _serializer = new JsonSerializer();
+
+        // Captured from a real POST /googlepay/enrollments 201 in sandbox.
+        private const string RealResponseBody = @"{
+            ""merchant_id"": ""12345678901234567890"",
+            ""tos_accepted_time"": ""2026-08-13T09:12:41Z"",
+            ""state"": ""ACTIVE""
+        }";
+
+        [Fact]
+        public void ShouldDeserializeTheRealEnrollmentResponse()
+        {
+            var response = (GooglePayEnrollmentResponse)_serializer
+                .Deserialize(RealResponseBody, typeof(GooglePayEnrollmentResponse));
+
+            response.ShouldNotBeNull();
+            response.MerchantId.ShouldBe("12345678901234567890");
+            response.TosAcceptedTime.ShouldNotBeNull();
+            response.State.ShouldBe(GooglePayEnrollmentState.Active);
+        }
+
+        /// <summary>
+        /// merchant_id is what the caller needs to initialise Google Pay on the client, so
+        /// losing it is the whole defect. Asserted on its own to make that unmissable.
+        /// </summary>
+        [Fact]
+        public void ShouldNotSilentlyDropMerchantId()
+        {
+            var response = (GooglePayEnrollmentResponse)_serializer
+                .Deserialize(RealResponseBody, typeof(GooglePayEnrollmentResponse));
+
+            response.MerchantId.ShouldNotBeNullOrEmpty();
+        }
+
+        /// <summary>
+        /// The API does not always return every field, and a missing merchant_id must come back
+        /// null rather than empty: a caller has to be able to tell "not returned" from "blank".
+        /// </summary>
+        [Fact]
+        public void ShouldLeaveMerchantIdNullWhenAbsent()
+        {
+            const string json = @"{
+                ""tos_accepted_time"": ""2026-08-13T09:12:41Z"",
+                ""state"": ""ACTIVE""
+            }";
+
+            var response = (GooglePayEnrollmentResponse)_serializer
+                .Deserialize(json, typeof(GooglePayEnrollmentResponse));
+
+            response.MerchantId.ShouldBeNull();
+            response.State.ShouldBe(GooglePayEnrollmentState.Active);
+        }
+
+        [Fact]
+        public void ShouldSerializeMerchantIdAsSnakeCase()
+        {
+            var response = new GooglePayEnrollmentResponse
+            {
+                MerchantId = "12345678901234567890",
+                State = GooglePayEnrollmentState.Active
+            };
+
+            var json = _serializer.Serialize(response);
+
+            json.ShouldContain("\"merchant_id\":\"12345678901234567890\"");
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds `merchant_id` to the Google Pay enrollment response.

Reported internally on behalf of a merchant. `merchant_id` is what the caller needs to initialise Google Pay on the client, so without it the enrollment response is not usable for its purpose.

## The root cause is the spec, not this SDK

`GooglePayEnrollmentResponse` in the spec declares only `tosAcceptedTime` and `state`, both required, omits `merchant_id`, and sets `additionalProperties: false`.

The real 201 from `POST /googlepay/enrollments` returns:

```json
{
  "merchant_id": "12345678901234567890",
  "tos_accepted_time": "2026-08-13T09:12:41Z",
  "state": "ACTIVE"
}
```

The model was generated faithfully from a wrong schema. **The spec fix is being raised separately and is the actual fix**: until it lands, the next regeneration reintroduces this.

## Tests

They deserialize the real sandbox body, not the swagger example, because the swagger example is the thing that was wrong. One test asserts `merchant_id` survives on its own, since losing it is the entire defect, and another asserts an absent `merchant_id` comes back null rather than blank, so a caller can tell "not returned" from "returned empty".

## Not breaking

Purely additive on a response model.

Refs INT-1690.

## Note on the timestamp

`TosAcceptedTime` already worked here: `JsonSerializer` applies `SnakeCaseNamingStrategy` globally, so the property matches `tos_accepted_time` on the wire without an attribute. Only the missing field needed fixing.

4 tests green.