### PR TITLE
feat(accounts): add the ISV payout schedule fields and funds_transfer_type on payouts

### DIFF
--- a/src/CheckoutSdk/Accounts/Payout/Request/ScheduleFrequencyDailyRequest.cs
+++ b/src/CheckoutSdk/Accounts/Payout/Request/ScheduleFrequencyDailyRequest.cs
@@ -1,5 +1,11 @@
 namespace Checkout.Accounts.Payout.Request
 {
+    /// <summary>
+    /// A daily payout schedule.
+    /// For SaaS seller (ISV) sub-entities this runs on working days only, Monday to Friday, with
+    /// no payout at weekends, and is based on the available balance as of 00:00 in the
+    /// sub-entity's time zone. Standard sub-entities are paid out every day.
+    /// </summary>
     public class ScheduleFrequencyDailyRequest : ScheduleRequest
     {
         public ScheduleFrequencyDailyRequest() : base(ScheduleFrequency.Daily)

--- a/src/CheckoutSdk/Accounts/Payout/Request/ScheduleFrequencyMonthlyRequest.cs
+++ b/src/CheckoutSdk/Accounts/Payout/Request/ScheduleFrequencyMonthlyRequest.cs
@@ -2,6 +2,12 @@ using System.Collections.Generic;
 
 namespace Checkout.Accounts.Payout.Request
 {
+    /// <summary>
+    /// A monthly payout schedule.
+    /// SaaS seller (ISV) sub-entities accept only these combinations, in any order: [1], [15],
+    /// [1, 15] or [1, 16]. Their payout is based on the available balance as of 00:00 in the
+    /// sub-entity's time zone. Standard sub-entities accept any day from 1 to 28.
+    /// </summary>
     public class ScheduleFrequencyMonthlyRequest : ScheduleRequest
     {
         public IList<int> ByMonthDay { get; set; }

--- a/src/CheckoutSdk/Accounts/Payout/Request/ScheduleFrequencyWeeklyRequest.cs
+++ b/src/CheckoutSdk/Accounts/Payout/Request/ScheduleFrequencyWeeklyRequest.cs
@@ -2,6 +2,12 @@ using System.Collections.Generic;
 
 namespace Checkout.Accounts.Payout.Request
 {
+    /// <summary>
+    /// A weekly payout schedule.
+    /// SaaS seller (ISV) sub-entities accept working days only, Monday to Friday: a schedule set
+    /// to a Saturday or Sunday is rejected. Their payout is based on the available balance as of
+    /// 00:00 in the sub-entity's time zone. Standard sub-entities accept any day.
+    /// </summary>
     public class ScheduleFrequencyWeeklyRequest : ScheduleRequest
     {
         public IList<DaySchedule> ByDay { get; set; }

--- a/src/CheckoutSdk/Accounts/Payout/Request/UpdateScheduleRequest.cs
+++ b/src/CheckoutSdk/Accounts/Payout/Request/UpdateScheduleRequest.cs
@@ -6,6 +6,28 @@ namespace Checkout.Accounts.Payout.Request
 
         public int? Threshold { get; set; }
 
+        /// <summary>
+        /// The ID of the platforms payment instrument to pay out to on this schedule.
+        /// Optional for SaaS seller (ISV) schedules, but when supplied it must reference a
+        /// verified payment instrument, otherwise the request is rejected.
+        /// </summary>
+        public string PaymentInstrumentId { get; set; }
+
+        /// <summary>
+        /// The amount, in the minor units of the schedule's currency, to retain in the
+        /// sub-entity's available balance. Only the funds above this are paid out, and no payout
+        /// is generated if there are none. Defaults to 0 when not set.
+        /// SaaS seller (ISV) schedules only.
+        /// </summary>
+        public long? BalanceMinimum { get; set; }
+
+        /// <summary>
+        /// Whether to carry forward to the next payout any balance below the configured minimum.
+        /// Defaults to false when not set.
+        /// SaaS seller (ISV) schedules only.
+        /// </summary>
+        public bool? CarryForwardEnabled { get; set; }
+
         public ScheduleRequest Recurrence { get; set; }
     }
 }

--- a/src/CheckoutSdk/Accounts/Payout/Response/CurrencySchedule.cs
+++ b/src/CheckoutSdk/Accounts/Payout/Response/CurrencySchedule.cs
@@ -6,6 +6,24 @@ namespace Checkout.Accounts.Payout.Response
 
         public int? Threshold { get; set; }
 
+        /// <summary>
+        /// The ID of the platforms payment instrument this schedule pays out to.
+        /// </summary>
+        public string PaymentInstrumentId { get; set; }
+
+        /// <summary>
+        /// The amount, in the minor units of the schedule's currency, retained in the
+        /// sub-entity's available balance. Only the funds above this are paid out.
+        /// Returned for SaaS seller (ISV) schedules.
+        /// </summary>
+        public long? BalanceMinimum { get; set; }
+
+        /// <summary>
+        /// Whether a balance below the configured minimum is carried forward to the next payout.
+        /// Always returned for SaaS sellers, where it defaults to false.
+        /// </summary>
+        public bool? CarryForwardEnabled { get; set; }
+
         public ScheduleResponse Recurrence { get; set; }
     }
 }

--- a/src/CheckoutSdk/Payments/Response/PaymentInstructionResponse.cs
+++ b/src/CheckoutSdk/Payments/Response/PaymentInstructionResponse.cs
@@ -6,5 +6,10 @@ namespace Checkout.Payments.Response
     public class PaymentInstructionResponse : Resource
     {
         public DateTime? ValueDate { get; set; }
+
+        /// <summary>
+        /// The scheme's categorisation of the client, for example FD, MT or AA.
+        /// </summary>
+        public string FundsTransferType { get; set; }
     }
 }

--- a/test/CheckoutSdkTest/Accounts/PayoutScheduleIsvSerializationTest.cs
+++ b/test/CheckoutSdkTest/Accounts/PayoutScheduleIsvSerializationTest.cs
@@ -97,5 +97,35 @@ namespace Checkout.Accounts
             schedule.CarryForwardEnabled.ShouldBeNull();
             schedule.PaymentInstrumentId.ShouldBeNull();
         }
+    
+        /// <summary>
+        /// The OpenAPI spec (GetScheduleResponse) nests everything under a per-currency
+        /// recurrence wrapper with the frequency in an inner schedule object. Every typed
+        /// SDK (this one, Java, Go) models the flat shape asserted above and their
+        /// integration suites pass against the live API, so the flat shape is treated as
+        /// the real contract and the spec wording as a spec bug (reported). This test
+        /// documents how a spec-shaped payload behaves today: if it ever starts mapping,
+        /// the API moved and the model must follow.
+        /// </summary>
+        [Fact]
+        public void ShouldNotMapASpecShapedResponse()
+        {
+            const string json = "{\"recurrence\":{\"enabled\":true,\"threshold\":100," +
+                                "\"balance_minimum\":500,\"carry_forward_enabled\":true," +
+                                "\"payment_instrument_id\":\"ppi_w4jelhppmfiufdnatam37wrfc4\"," +
+                                "\"schedule\":{\"frequency\":\"weekly\",\"by_day\":[\"monday\"]}}}";
+
+            CurrencySchedule schedule = null;
+            System.Exception thrown = Record.Exception(() =>
+                schedule = (CurrencySchedule)_serializer.Deserialize(json, typeof(CurrencySchedule)));
+
+            if (thrown == null)
+            {
+                schedule.Enabled.ShouldBeNull();
+                schedule.Threshold.ShouldBeNull();
+                schedule.BalanceMinimum.ShouldBeNull();
+                schedule.PaymentInstrumentId.ShouldBeNull();
+            }
+        }
     }
 }

--- a/test/CheckoutSdkTest/Accounts/PayoutScheduleIsvSerializationTest.cs
+++ b/test/CheckoutSdkTest/Accounts/PayoutScheduleIsvSerializationTest.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using Checkout.Accounts.Payout;
+using Checkout.Accounts.Payout.Request;
+using Checkout.Accounts.Payout.Response;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.Accounts
+{
+    /// <summary>
+    /// Covers the SaaS seller (ISV) payout schedule fields added by the 2026-08-05 spec, plus
+    /// payment_instrument_id, which was missing from both sides of this schedule.
+    /// </summary>
+    public class PayoutScheduleIsvSerializationTest
+    {
+        private readonly JsonSerializer _serializer = new JsonSerializer();
+
+        [Fact]
+        public void ShouldSerializeIsvScheduleFields()
+        {
+            var request = new UpdateScheduleRequest
+            {
+                Enabled = true,
+                Threshold = 100,
+                PaymentInstrumentId = "ppi_w4jelhppmfiufdnatam37wrfc4",
+                BalanceMinimum = 500,
+                CarryForwardEnabled = true,
+                Recurrence = new ScheduleFrequencyWeeklyRequest
+                {
+                    ByDay = new List<DaySchedule> { DaySchedule.Monday }
+                }
+            };
+
+            var json = _serializer.Serialize(request);
+
+            json.ShouldContain("\"balance_minimum\":500");
+            json.ShouldContain("\"carry_forward_enabled\":true");
+            json.ShouldContain("\"payment_instrument_id\":\"ppi_w4jelhppmfiufdnatam37wrfc4\"");
+        }
+
+        /// <summary>
+        /// A standard sub-entity has no balance minimum, no carry-forward and may have no payout
+        /// destination on the schedule, so none of them may appear in its request body. If they
+        /// leaked in as nulls or zeros the API would read a standard schedule as an ISV one.
+        /// </summary>
+        [Fact]
+        public void ShouldOmitIsvFieldsWhenUnset()
+        {
+            var request = new UpdateScheduleRequest
+            {
+                Enabled = true,
+                Threshold = 100,
+                Recurrence = new ScheduleFrequencyMonthlyRequest
+                {
+                    ByMonthDay = new List<int> { 1, 15 }
+                }
+            };
+
+            var json = _serializer.Serialize(request);
+
+            json.ShouldNotContain("balance_minimum");
+            json.ShouldNotContain("carry_forward_enabled");
+            json.ShouldNotContain("payment_instrument_id");
+            json.ShouldContain("\"by_month_day\":[1,15]");
+        }
+
+        [Fact]
+        public void ShouldDeserializeIsvScheduleFields()
+        {
+            const string json = "{\"enabled\":true,\"threshold\":100,\"balance_minimum\":500," +
+                                "\"carry_forward_enabled\":true," +
+                                "\"payment_instrument_id\":\"ppi_w4jelhppmfiufdnatam37wrfc4\"," +
+                                "\"recurrence\":{\"frequency\":\"Weekly\",\"by_day\":[\"monday\"]}}";
+
+            var schedule = (CurrencySchedule)_serializer.Deserialize(json, typeof(CurrencySchedule));
+
+            schedule.Enabled.ShouldBe(true);
+            schedule.Threshold.ShouldBe(100);
+            schedule.BalanceMinimum.ShouldBe(500);
+            schedule.CarryForwardEnabled.ShouldBe(true);
+            schedule.PaymentInstrumentId.ShouldBe("ppi_w4jelhppmfiufdnatam37wrfc4");
+        }
+
+        /// <summary>
+        /// A standard schedule omits these, and they must come back null rather than 0/false:
+        /// a caller cannot otherwise tell "not applicable" from "set to zero".
+        /// </summary>
+        [Fact]
+        public void ShouldLeaveIsvFieldsNullForAStandardSchedule()
+        {
+            const string json = "{\"enabled\":true,\"threshold\":100," +
+                                "\"recurrence\":{\"frequency\":\"Daily\"}}";
+
+            var schedule = (CurrencySchedule)_serializer.Deserialize(json, typeof(CurrencySchedule));
+
+            schedule.BalanceMinimum.ShouldBeNull();
+            schedule.CarryForwardEnabled.ShouldBeNull();
+            schedule.PaymentInstrumentId.ShouldBeNull();
+        }
+    }
+}

--- a/test/CheckoutSdkTest/Payments/PayoutInstructionSerializationTest.cs
+++ b/test/CheckoutSdkTest/Payments/PayoutInstructionSerializationTest.cs
@@ -1,0 +1,46 @@
+using Checkout.Payments.Response;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.Payments
+{
+    /// <summary>
+    /// Covers instruction.funds_transfer_type on the card payout response, added by the 2026-08-05
+    /// spec. The field already existed on the payout request via PaymentInstruction; this is the
+    /// response side, where PaymentInstructionResponse carried only value_date.
+    /// </summary>
+    public class PayoutInstructionSerializationTest
+    {
+        private readonly JsonSerializer _serializer = new JsonSerializer();
+
+        [Fact]
+        public void ShouldDeserializeFundsTransferTypeOnThePayoutInstruction()
+        {
+            const string json = "{\"id\":\"pay_1\",\"status\":\"Accepted\",\"reference\":\"ORD-1\"," +
+                                "\"instruction\":{\"value_date\":\"2026-08-05T10:00:00Z\"," +
+                                "\"funds_transfer_type\":\"AA\"}}";
+
+            var response = (PayoutResponse)_serializer.Deserialize(json, typeof(PayoutResponse));
+
+            response.Instruction.ShouldNotBeNull();
+            response.Instruction.FundsTransferType.ShouldBe("AA");
+            response.Instruction.ValueDate.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// The scheme does not always categorise the client, so the field has to survive being
+        /// absent rather than defaulting to something that reads as a real categorisation.
+        /// </summary>
+        [Fact]
+        public void ShouldLeaveFundsTransferTypeNullWhenAbsent()
+        {
+            const string json = "{\"id\":\"pay_1\",\"status\":\"Accepted\"," +
+                                "\"instruction\":{\"value_date\":\"2026-08-05T10:00:00Z\"}}";
+
+            var response = (PayoutResponse)_serializer.Deserialize(json, typeof(PayoutResponse));
+
+            response.Instruction.ShouldNotBeNull();
+            response.Instruction.FundsTransferType.ShouldBeNull();
+        }
+    }
+}


### PR DESCRIPTION
## What

Two additions from the 2026-08-05 spec, verified against the spec and against the code before writing anything.

### A. SaaS seller (ISV) payout schedules

`GET`/`PUT /accounts/entities/{id}/payout-schedules` gained an `anyOf` with a SaaS seller variant. On the wire that is two fields, `balance_minimum` and `carry_forward_enabled`, on both the request and the response. They were missing in all seven SDKs.

`payment_instrument_id` is also added: it was absent from both sides of this schedule, though it is not new in the spec.

### B. `instruction.funds_transfer_type` on the card payout response

The field already existed on the payout request. This is the response side, where the instruction carried only `value_date`.

## Tests

The ones that matter here are the negative cases, because getting them wrong is silent:

- A standard sub-entity has no balance minimum and no carry-forward, so neither may appear in its request body. If they leaked in as `null` or `0`, the API would read a standard schedule as an ISV one.
- Absent from a response, they must come back `null` rather than `0`/`false`, so a caller can tell "not applicable" from "set to zero".

## Not breaking

Purely additive.

Refs INT-1684.