### PR TITLE
feature/INT-1693 - Payment sessions default values defect fix

### DIFF
--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionBase.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionBase.cs
@@ -38,10 +38,5 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
         /// </summary>
         [JsonProperty(PropertyName = "3ds")]
         public ThreeDsRequest ThreeDS { get; set; }
-
-        /// <summary>
-        /// Must be specified for card-not-present (CNP) payments. Default: "Regular"
-        /// </summary>
-        public PaymentType? PaymentType { get; set; } = Checkout.Payments.PaymentType.Regular;
     }
 }

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionCompleteRequest.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionCompleteRequest.cs
@@ -3,7 +3,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
     /// <summary>
     /// Request to create and complete a payment session in one operation.
     /// </summary>
-    public class PaymentSessionCompleteRequest : PaymentSessionInfo
+    public class PaymentSessionCompleteRequest : PaymentSessionCreateBase
     {
         /// <summary>
         /// A unique token representing the additional customer data captured by Flow, 

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionCreateBase.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionCreateBase.cs
@@ -1,0 +1,66 @@
+using Checkout.Payments;
+
+namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
+{
+    /// <summary>
+    /// Base class for the payment session requests that create a session.
+    ///
+    /// The properties declared here are accepted only when a payment session is created, either by
+    /// Request a Payment Session (POST /payment-sessions) or by Request a Payment Session with
+    /// Payment (POST /payment-sessions/complete). They are not accepted by Submit a Payment
+    /// Session (POST /payment-sessions/{id}/submit), which is why PaymentSessionSubmitRequest
+    /// does not derive from this class.
+    ///
+    /// The defaults declared here mirror the API defaults, so a request that omits them behaves
+    /// the same whether or not the SDK sends them.
+    /// </summary>
+    public abstract class PaymentSessionCreateBase : PaymentSessionInfo
+    {
+        /// <summary>
+        /// Specifies whether to capture the payment, if applicable. Default: true
+        /// </summary>
+        public bool? Capture { get; set; } = true;
+
+        /// <summary>
+        /// Must be specified for card-not-present (CNP) payments. Default: "Regular"
+        /// Enum: "Regular" "Recurring" "MOTO" "Installment" "Unscheduled"
+        /// </summary>
+        public PaymentType? PaymentType { get; set; } = Checkout.Payments.PaymentType.Regular;
+
+        /// <summary>
+        /// Creates a translated version of the page in the specified language. Default: "en-GB"
+        /// </summary>
+        public LocaleType? Locale { get; set; } = LocaleType.EnGb;
+
+        /// <summary>
+        /// The authorization type.
+        /// [Optional]
+        /// Enum: "Final" "Estimated"
+        /// Default: "Final"
+        /// </summary>
+        public AuthorizationType? AuthorizationType { get; set; }
+
+        /// <summary>
+        /// A description for the payment.
+        /// max 100 characters
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The merchant's display name.
+        /// max 255 characters
+        /// </summary>
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The information to process a recurring payment request. To be used when the payment_type is Recurring.
+        /// [Optional]
+        /// </summary>
+        public PaymentPlan PaymentPlan { get; set; }
+
+        /// <summary>
+        /// Configures the risk assessment performed during payment processing.
+        /// </summary>
+        public RiskRequest Risk { get; set; }
+    }
+}

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionCreateRequest.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionCreateRequest.cs
@@ -9,7 +9,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
     /// <summary>
     /// Request to create a payment session.
     /// </summary>
-    public class PaymentSessionCreateRequest : PaymentSessionInfo
+    public class PaymentSessionCreateRequest : PaymentSessionCreateBase
     {
         /// <summary>
         /// A timestamp specifying when the PaymentSession should expire, as an ISO 8601 code.

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionInfo.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionInfo.cs
@@ -10,33 +10,39 @@ using System.Collections.Generic;
 namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
 {
     /// <summary>
-    /// Extended base class for payment session requests that include full payment details
+    /// Extended base class for payment session requests that include full payment details.
+    ///
+    /// This class holds only the properties that every payment session request accepts, whether it
+    /// creates a session or submits a payment attempt for an existing one. Properties that only the
+    /// session creation endpoints accept live in PaymentSessionCreateBase.
     /// </summary>
     public abstract class PaymentSessionInfo : PaymentSessionBase
     {
         /// <summary>
-        /// The three-letter ISO currency code
-        /// [Required]
+        /// The three-letter ISO currency code.
+        /// Nullable so that a submit request omits it unless the caller sets it, which leaves the
+        /// value provided when the payment session was created untouched.
+        /// [Required] when creating a payment session
         /// </summary>
-        public Currency Currency { get; set; }
+        public Currency? Currency { get; set; }
 
         /// <summary>
         /// The billing details.
-        /// [Required]
+        /// [Required] when creating a payment session
         /// </summary>
         public BillingInformation Billing { get; set; }
 
         /// <summary>
-        /// Overrides the default success redirect URL configured on your account, 
+        /// Overrides the default success redirect URL configured on your account,
         /// for payment methods that require a redirect.
-        /// [Required]
+        /// [Required] when creating a payment session
         /// </summary>
         public string SuccessUrl { get; set; }
 
         /// <summary>
-        /// Overrides the default failure redirect URL configured on your account, 
+        /// Overrides the default failure redirect URL configured on your account,
         /// for payment methods that require a redirect.
-        /// [Required]
+        /// [Required] when creating a payment session
         /// </summary>
         public string FailureUrl { get; set; }
 
@@ -46,17 +52,12 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
         public BillingDescriptor BillingDescriptor { get; set; }
 
         /// <summary>
-        /// A description for the payment.
-        /// </summary>
-        public string Description { get; set; }
-
-        /// <summary>
         /// The customer's details. Required if source.type is tamara.
         /// </summary>
         public Customer.Customer Customer { get; set; }
 
         /// <summary>
-        /// The shipping details
+        /// The shipping details.
         /// </summary>
         public ShippingDetails Shipping { get; set; }
 
@@ -66,7 +67,7 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
         public PaymentRecipient Recipient { get; set; }
 
         /// <summary>
-        /// Use the processing object to influence or override the data sent during card processing
+        /// Use the processing object to influence or override the data sent during card processing.
         /// </summary>
         public ProcessingSettings Processing { get; set; }
 
@@ -82,18 +83,9 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
 
         /// <summary>
         /// The sub-entities that the payment is being processed on behalf of.
+        /// min 1 max 50 items
         /// </summary>
         public IList<AmountAllocations> AmountAllocations { get; set; }
-
-        /// <summary>
-        /// Configures the risk assessment performed during payment processing.
-        /// </summary>
-        public RiskRequest Risk { get; set; }
-
-        /// <summary>
-        /// The merchant's display name.
-        /// </summary>
-        public string DisplayName { get; set; }
 
         /// <summary>
         /// Allows you to store additional information about a transaction with custom fields.
@@ -101,37 +93,14 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
         public Dictionary<string, object> Metadata { get; set; }
 
         /// <summary>
-        /// Creates a translated version of the page in the specified language. Default: "en-GB"
-        /// </summary>
-        public LocaleType? Locale { get; set; } = LocaleType.EnGb;
-
-        /// <summary>
         /// The sender of the payment.
         /// </summary>
         public PaymentSender Sender { get; set; }
 
         /// <summary>
-        /// Specifies whether to capture the payment, if applicable. Default: true
-        /// </summary>
-        public bool? Capture { get; set; } = true;
-
-        /// <summary>
         /// A timestamp specifying when to capture the payment, as an ISO 8601 code.
+        /// If a value is provided, capture is automatically set to true by the API.
         /// </summary>
         public DateTime? CaptureOn { get; set; }
-
-        /// <summary>
-        /// The authorization type.
-        /// [Optional]
-        /// Enum: "Final" "Estimated"
-        /// Default: "Final"
-        /// </summary>
-        public AuthorizationType? AuthorizationType { get; set; }
-
-        /// <summary>
-        /// The information to process a recurring payment request. To be used when the payment_type is Recurring.
-        /// [Optional]
-        /// </summary>
-        public PaymentPlan PaymentPlan { get; set; }
     }
 }

--- a/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionSubmitRequest.cs
+++ b/src/CheckoutSdk/HandlePaymentsAndPayouts/Flow/Requests/PaymentSessionSubmitRequest.cs
@@ -1,9 +1,16 @@
 using Checkout.HandlePaymentsAndPayouts.Flow.Entities;
 
+using PaymentType = Checkout.Payments.PaymentType;
+
 namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
 {
     /// <summary>
     /// Request to submit a payment session.
+    ///
+    /// Every property is optional except SessionData. A property you do not set is omitted from
+    /// the request body, which leaves the value provided when the payment session was created
+    /// untouched. This is why Capture and PaymentType carry no default here, unlike on the
+    /// session creation requests.
     /// </summary>
     public class PaymentSessionSubmitRequest : PaymentSessionInfo
     {
@@ -14,6 +21,21 @@ namespace Checkout.HandlePaymentsAndPayouts.Flow.Requests
         /// [Required]
         /// </summary>
         public string SessionData { get; set; }
+
+        /// <summary>
+        /// Specifies whether to capture the payment, if applicable.
+        /// Leave this property unset to keep the value provided when the payment session was
+        /// created. If it was not provided then either, the API applies its default of true.
+        /// </summary>
+        public bool? Capture { get; set; }
+
+        /// <summary>
+        /// Must be specified for card-not-present (CNP) payments.
+        /// Leave this property unset to keep the value provided when the payment session was
+        /// created. If it was not provided then either, the API applies its default of "Regular".
+        /// Enum: "Regular" "Recurring" "MOTO" "Installment" "Unscheduled"
+        /// </summary>
+        public PaymentType? PaymentType { get; set; }
 
         /// <summary>
         /// Configurations for payment method-specific settings.

--- a/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Flow/PaymentSessionCaptureDefaultsTest.cs
+++ b/test/CheckoutSdkTest/HandlePaymentsAndPayouts/Flow/PaymentSessionCaptureDefaultsTest.cs
@@ -1,0 +1,222 @@
+using Checkout.Common;
+using Checkout.HandlePaymentsAndPayouts.Flow.Requests;
+using Checkout.Payments;
+using Shouldly;
+using Xunit;
+
+namespace Checkout.HandlePaymentsAndPayouts.Flow
+{
+    /// <summary>
+    /// Regression tests for the capture and payment_type defaults on the Flow payment session requests.
+    ///
+    /// The session creation requests (POST /payment-sessions and POST /payment-sessions/complete) must
+    /// keep sending the API defaults, because the caller is supplying the payment's values in that same
+    /// call. The submit request (POST /payment-sessions/{id}/submit) must send neither property unless
+    /// the caller sets it, because any value present in the submit body is applied to the payment
+    /// attempt and would overwrite the value provided when the payment session was created.
+    /// </summary>
+    public class PaymentSessionCaptureDefaultsTest
+    {
+        [Fact]
+        public void ShouldOnlySerializeSessionDataWhenNothingElseIsSet()
+        {
+            var request = new PaymentSessionSubmitRequest
+            {
+                SessionData = "SD"
+            };
+
+            var json = new JsonSerializer().Serialize(request);
+
+            json.ShouldBe("{\"session_data\":\"SD\"}");
+        }
+
+        [Fact]
+        public void ShouldLeaveCaptureAndPaymentTypeNullOnSubmitWhenNotSet()
+        {
+            var request = new PaymentSessionSubmitRequest
+            {
+                SessionData = "SD"
+            };
+
+            request.Capture.ShouldBeNull();
+            request.PaymentType.ShouldBeNull();
+        }
+
+        [Fact]
+        public void ShouldSerializeCaptureFalseOnSubmitWhenExplicitlySet()
+        {
+            var request = new PaymentSessionSubmitRequest
+            {
+                SessionData = "SD",
+                Capture = false
+            };
+
+            var json = new JsonSerializer().Serialize(request);
+
+            json.ShouldContain("\"capture\":false");
+        }
+
+        [Fact]
+        public void ShouldSerializeCaptureAndPaymentTypeOnSubmitWhenExplicitlySet()
+        {
+            var request = new PaymentSessionSubmitRequest
+            {
+                SessionData = "SD",
+                Capture = true,
+                PaymentType = PaymentType.Recurring
+            };
+
+            var json = new JsonSerializer().Serialize(request);
+
+            json.ShouldContain("\"capture\":true");
+            json.ShouldContain("\"payment_type\":\"Recurring\"");
+        }
+
+        [Fact]
+        public void ShouldRoundTripCaptureAndPaymentTypeOnSubmit()
+        {
+            var original = new PaymentSessionSubmitRequest
+            {
+                SessionData = "SD",
+                Capture = false,
+                PaymentType = PaymentType.Moto,
+                Amount = 2500,
+                Currency = Currency.USD
+            };
+
+            var serializer = new JsonSerializer();
+            var json = serializer.Serialize(original);
+            var deserialized = (PaymentSessionSubmitRequest)serializer.Deserialize(json, typeof(PaymentSessionSubmitRequest));
+
+            deserialized.SessionData.ShouldBe("SD");
+            deserialized.Capture.ShouldBe(false);
+            deserialized.PaymentType.ShouldBe(PaymentType.Moto);
+            deserialized.Amount.ShouldBe(2500L);
+            deserialized.Currency.ShouldBe(Currency.USD);
+        }
+
+        [Fact]
+        public void ShouldNotSerializeSessionCreationOnlyFieldsOnSubmit()
+        {
+            var request = new PaymentSessionSubmitRequest
+            {
+                SessionData = "SD",
+                Amount = 1000,
+                Currency = Currency.GBP,
+                Capture = true,
+                PaymentType = PaymentType.Regular
+            };
+
+            var json = new JsonSerializer().Serialize(request);
+
+            json.ShouldNotContain("\"locale\"");
+            json.ShouldNotContain("\"description\"");
+            json.ShouldNotContain("\"display_name\"");
+            json.ShouldNotContain("\"authorization_type\"");
+            json.ShouldNotContain("\"payment_plan\"");
+            json.ShouldNotContain("\"risk\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeTheApiDefaultsOnCreate()
+        {
+            var request = new PaymentSessionCreateRequest
+            {
+                Amount = 1000,
+                Currency = Currency.GBP
+            };
+
+            var json = new JsonSerializer().Serialize(request);
+
+            json.ShouldContain("\"capture\":true");
+            json.ShouldContain("\"payment_type\":\"Regular\"");
+            json.ShouldContain("\"locale\":\"en-GB\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeTheApiDefaultsOnComplete()
+        {
+            var request = new PaymentSessionCompleteRequest
+            {
+                SessionData = "SD",
+                Amount = 2000,
+                Currency = Currency.USD
+            };
+
+            var json = new JsonSerializer().Serialize(request);
+
+            json.ShouldContain("\"capture\":true");
+            json.ShouldContain("\"payment_type\":\"Regular\"");
+            json.ShouldContain("\"locale\":\"en-GB\"");
+        }
+
+        [Fact]
+        public void ShouldStillAllowOverridingTheDefaultsOnCreate()
+        {
+            var request = new PaymentSessionCreateRequest
+            {
+                Amount = 1000,
+                Currency = Currency.GBP,
+                Capture = false,
+                PaymentType = PaymentType.Unscheduled,
+                Locale = LocaleType.FrFr
+            };
+
+            var json = new JsonSerializer().Serialize(request);
+
+            json.ShouldContain("\"capture\":false");
+            json.ShouldContain("\"payment_type\":\"Unscheduled\"");
+            json.ShouldContain("\"locale\":\"fr-FR\"");
+        }
+
+        [Fact]
+        public void ShouldRoundTripEverySessionCreationOnlyFieldOnCreate()
+        {
+            var original = new PaymentSessionCreateRequest
+            {
+                Capture = false,
+                PaymentType = PaymentType.Installment,
+                Locale = LocaleType.DeDe,
+                AuthorizationType = AuthorizationType.Estimated,
+                Description = "Payment for gold necklace",
+                DisplayName = "Example Store",
+                PaymentPlan = new PaymentPlan
+                {
+                    AmountVariability = AmountVariabilityType.Fixed,
+                    DaysBetweenPayments = 28
+                },
+                Risk = new RiskRequest
+                {
+                    Enabled = false
+                }
+            };
+
+            var serializer = new JsonSerializer();
+            var json = serializer.Serialize(original);
+            var deserialized = (PaymentSessionCreateRequest)serializer.Deserialize(json, typeof(PaymentSessionCreateRequest));
+
+            deserialized.Capture.ShouldBe(false);
+            deserialized.PaymentType.ShouldBe(PaymentType.Installment);
+            deserialized.Locale.ShouldBe(LocaleType.DeDe);
+            deserialized.AuthorizationType.ShouldBe(AuthorizationType.Estimated);
+            deserialized.Description.ShouldBe("Payment for gold necklace");
+            deserialized.DisplayName.ShouldBe("Example Store");
+            deserialized.PaymentPlan.AmountVariability.ShouldBe(AmountVariabilityType.Fixed);
+            deserialized.PaymentPlan.DaysBetweenPayments.ShouldBe(28);
+            deserialized.Risk.Enabled.ShouldBe(false);
+        }
+
+        [Fact]
+        public void ShouldDeserializeTheDocumentedSubmitExample()
+        {
+            const string json = "{\"session_data\":\"{SESSION_DATA_FROM_FLOW}\",\"3ds\":{\"enabled\":true}}";
+
+            var request = (PaymentSessionSubmitRequest)new JsonSerializer().Deserialize(json, typeof(PaymentSessionSubmitRequest));
+
+            request.SessionData.ShouldBe("{SESSION_DATA_FROM_FLOW}");
+            request.ThreeDS.Enabled.ShouldBe(true);
+            request.Capture.ShouldBeNull();
+            request.PaymentType.ShouldBeNull();
+        }
+    }
+}


### PR DESCRIPTION
This pull request  fixes a defect in the payment sessions default values, refactors and clarifies the handling of default properties for Flow payment session requests in the SDK. It introduces a new base class to clearly separate properties relevant only to session creation from those shared with session submission, ensures correct serialization behavior, and adds comprehensive regression tests to verify the new logic.

**Refactoring and separation of session creation vs. submission properties:**

* Introduced a new abstract base class, `PaymentSessionCreateBase`, which contains properties (`Capture`, `PaymentType`, `Locale`, `AuthorizationType`, `Description`, `DisplayName`, `PaymentPlan`, `Risk`) that are only relevant when creating a payment session. This ensures these defaults are only sent when appropriate and not during session submission.
* Updated `PaymentSessionCreateRequest` and `PaymentSessionCompleteRequest` to inherit from `PaymentSessionCreateBase` instead of `PaymentSessionInfo`, so they include only the relevant creation properties. [[1]](diffhunk://#diff-c50a28df009ad42caec6e4c7b096309d15f236a9c55e8effcf3a0813239c472fL12-R12) [[2]](diffhunk://#diff-51a8c3098d5edf42596447e16768b60584d3b1aeec0bb4e6fa1c7a12fe7feffaL6-R6)
* Removed creation-only properties from `PaymentSessionInfo` and clarified its documentation to reflect that it now only contains properties accepted by all payment session requests. [[1]](diffhunk://#diff-5abe4dc655530cc1c3fd8937f8c48629259b87b3a1c43e1f9f441c177f743d14L13-R45) [[2]](diffhunk://#diff-5abe4dc655530cc1c3fd8937f8c48629259b87b3a1c43e1f9f441c177f743d14L48-R60) [[3]](diffhunk://#diff-5abe4dc655530cc1c3fd8937f8c48629259b87b3a1c43e1f9f441c177f743d14R86-L135) [[4]](diffhunk://#diff-5abe4dc655530cc1c3fd8937f8c48629259b87b3a1c43e1f9f441c177f743d14L69-R70)

**Default property handling and serialization improvements:**

* Removed `PaymentType` from `PaymentSessionBase` and updated logic so that the submit request (`PaymentSessionSubmitRequest`) only includes `Capture` and `PaymentType` if explicitly set by the caller, avoiding unintended overwrites of session values. [[1]](diffhunk://#diff-3039910be9d1efe98d807cd83da2a1e07bbaa0ae9471b20c5c1f1639be00c42eL41-L45) [[2]](diffhunk://#diff-e767a402e475af304e7d87a5d259332dbb45f4a10b6a5086adbbf0b4e0b03b34R3-R13) [[3]](diffhunk://#diff-e767a402e475af304e7d87a5d259332dbb45f4a10b6a5086adbbf0b4e0b03b34R25-R39)

**Testing:**

* Added a comprehensive test suite (`PaymentSessionCaptureDefaultsTest`) to verify default property behavior for session creation and submission, including serialization, deserialization, and property round-tripping.