### PR TITLE
feat(payments): add optional amount to VoidRequest for partial voids

### DIFF
--- a/src/CheckoutSdk/Payments/VoidRequest.cs
+++ b/src/CheckoutSdk/Payments/VoidRequest.cs
@@ -4,6 +4,11 @@ namespace Checkout.Payments
 {
     public class VoidRequest
     {
+        /// <summary>
+        /// The amount to void, min 0, max 9999999999. If not specified, the full payment amount is voided.
+        /// </summary>
+        public long? Amount { get; set; }
+
         public string Reference { get; set; }
 
         public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();

--- a/test/CheckoutSdkTest/Payments/VoidRequestSerializationTest.cs
+++ b/test/CheckoutSdkTest/Payments/VoidRequestSerializationTest.cs
@@ -1,0 +1,84 @@
+using Shouldly;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Checkout.Payments
+{
+    public class VoidRequestSerializationTest
+    {
+        private static readonly JsonSerializer Serializer = new JsonSerializer();
+
+        private static VoidRequest CreateFullyPopulated()
+        {
+            return new VoidRequest
+            {
+                Amount = 100L,
+                Reference = "ORD-5023-4E89",
+                Metadata = new Dictionary<string, object> { { "coupon_code", "NY2018" } }
+            };
+        }
+
+        [Fact]
+        public void ShouldSerializeWithRequiredProperties()
+        {
+            var request = new VoidRequest();
+
+            Should.NotThrow(() => Serializer.Serialize(request));
+        }
+
+        [Fact]
+        public void ShouldSerializeAllOptionalPropertiesToSnakeCase()
+        {
+            var request = CreateFullyPopulated();
+
+            var json = Serializer.Serialize(request);
+
+            json.ShouldContain("\"amount\":100");
+            json.ShouldContain("\"reference\":\"ORD-5023-4E89\"");
+            json.ShouldContain("\"metadata\":{\"coupon_code\":\"NY2018\"}");
+        }
+
+        [Fact]
+        public void ShouldOmitAmountWhenNotSet()
+        {
+            var request = new VoidRequest { Reference = "ORD-5023-4E89" };
+
+            var json = Serializer.Serialize(request);
+
+            json.ShouldNotContain("amount");
+        }
+
+        [Fact]
+        public void ShouldRoundTripSerializeAllProperties()
+        {
+            var original = CreateFullyPopulated();
+
+            var json = Serializer.Serialize(original);
+            var deserialized = (VoidRequest)Serializer.Deserialize(json, typeof(VoidRequest));
+
+            deserialized.ShouldNotBeNull();
+            deserialized.Amount.ShouldBe(original.Amount);
+            deserialized.Reference.ShouldBe(original.Reference);
+            deserialized.Metadata.ShouldContainKeyAndValue("coupon_code", "NY2018");
+        }
+
+        [Fact]
+        public void ShouldDeserializeSwaggerExample()
+        {
+            const string json = @"{
+                ""amount"": 100,
+                ""reference"": ""ORD-5023-4E89"",
+                ""metadata"": {
+                    ""coupon_code"": ""NY2018""
+                }
+            }";
+
+            var request = (VoidRequest)Serializer.Deserialize(json, typeof(VoidRequest));
+
+            request.ShouldNotBeNull();
+            request.Amount.ShouldBe(100L);
+            request.Reference.ShouldBe("ORD-5023-4E89");
+            request.Metadata.ShouldContainKeyAndValue("coupon_code", "NY2018");
+        }
+    }
+}


### PR DESCRIPTION
**Summary**
Adds the optional `amount` field to the payment void request, introduced in the API spec on 2026-08-13. When set, only that amount is voided; when omitted, the full payment amount is voided, exactly as before.

**Changes**
- Void request model: new optional `amount` (integer, min 0, max 9999999999) with doc comment
- Serialization tests: amount present when set, and absent from the body when unset, so existing full-void callers keep sending an identical payload

**API Reference**
- `POST /payments/{id}/voids` (`VoidRequest.amount`)

**Breaking changes**
None.

**README**
No README impact.