### PR TITLE
feat(instruments): add SEPA mandate type to instrument_data

### DIFF
--- a/src/CheckoutSdk/Instruments/Create/InstrumentData.cs
+++ b/src/CheckoutSdk/Instruments/Create/InstrumentData.cs
@@ -6,6 +6,11 @@ namespace Checkout.Instruments.Create
 {
     public class InstrumentData
     {
+        /// <summary>
+        /// The type of SEPA mandate. Core or B2B.
+        /// </summary>
+        public SepaMandateType? Type { get; set; }
+
         public string AccountNumber { get; set; }
 
         public CountryCode? Country { get; set; }

--- a/src/CheckoutSdk/Instruments/Create/SepaMandateType.cs
+++ b/src/CheckoutSdk/Instruments/Create/SepaMandateType.cs
@@ -1,0 +1,16 @@
+using System.Runtime.Serialization;
+
+namespace Checkout.Instruments.Create
+{
+    /// <summary>
+    /// The type of SEPA mandate.
+    /// </summary>
+    public enum SepaMandateType
+    {
+        [EnumMember(Value = "Core")]
+        Core,
+
+        [EnumMember(Value = "B2B")]
+        B2B,
+    }
+}

--- a/test/CheckoutSdkTest/Instruments/Create/InstrumentDataSerializationTest.cs
+++ b/test/CheckoutSdkTest/Instruments/Create/InstrumentDataSerializationTest.cs
@@ -1,0 +1,70 @@
+using Checkout.Common;
+using Checkout.Payments;
+using Shouldly;
+using System;
+using Xunit;
+
+namespace Checkout.Instruments.Create
+{
+    /// <summary>
+    /// Schema validation tests for InstrumentData (SEPA instrument_data).
+    /// The type field carries the SEPA mandate type and must serialize with the
+    /// exact casing the API expects (Core, B2B), and stay out of the body when unset.
+    /// </summary>
+    public class InstrumentDataSerializationTest
+    {
+        private readonly JsonSerializer _serializer = new JsonSerializer();
+
+        [Fact]
+        private void ShouldSerializeWithAllFields()
+        {
+            var data = new InstrumentData
+            {
+                Type = SepaMandateType.B2B,
+                AccountNumber = "FR2810096000509685512959O86",
+                Country = CountryCode.FR,
+                Currency = Currency.EUR,
+                PaymentType = PaymentType.Recurring,
+                MandateId = "1234567890",
+                DateOfSignature = new DateTime(2021, 1, 1)
+            };
+
+            var json = _serializer.Serialize(data);
+
+            json.ShouldContain("\"type\":\"B2B\"");
+            json.ShouldContain("\"account_number\":\"FR2810096000509685512959O86\"");
+            json.ShouldContain("\"mandate_id\":\"1234567890\"");
+        }
+
+        [Fact]
+        private void ShouldSerializeCoreMandateType()
+        {
+            var data = new InstrumentData { Type = SepaMandateType.Core };
+
+            var json = _serializer.Serialize(data);
+
+            json.ShouldContain("\"type\":\"Core\"");
+        }
+
+        [Fact]
+        private void ShouldOmitTypeWhenNotSet()
+        {
+            var data = new InstrumentData { AccountNumber = "FR2810096000509685512959O86" };
+
+            var json = _serializer.Serialize(data);
+
+            json.ShouldNotContain("\"type\"");
+        }
+
+        [Fact]
+        private void ShouldDeserializeMandateType()
+        {
+            const string json = "{\"type\":\"B2B\",\"account_number\":\"FR2810096000509685512959O86\"}";
+
+            var data = (InstrumentData)_serializer.Deserialize(json, typeof(InstrumentData));
+
+            data.Type.ShouldBe(SepaMandateType.B2B);
+            data.AccountNumber.ShouldBe("FR2810096000509685512959O86");
+        }
+    }
+}


### PR DESCRIPTION
**Summary**
Adds the `type` field (SEPA mandate type) to the SEPA `instrument_data` model, verified against the spec: optional string enum with values `Core` and `B2B`.

**Changes**
- `src/CheckoutSdk/Instruments/Create/SepaMandateType.cs` — new enum with explicit EnumMember casing (`Core`, `B2B`)
- `src/CheckoutSdk/Instruments/Create/InstrumentData.cs` — new nullable `Type` property
- `test/CheckoutSdkTest/Instruments/Create/InstrumentDataSerializationTest.cs` — exact casing, omission when unset, deserialization

**API Reference**
- `POST /instruments` (`StoreSepaInstrumentRequest.instrument_data.type`)
- `PATCH /instruments/{id}` / `GET /instruments/{id}` (SEPA variants)

**Breaking changes**
None.

**README**
No README impact.