### PR TITLE
Release 6.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>5.8.1</Version>
+        <Version>6.0.0</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
- The merchant-specific subdomain (EnvironmentSubdomain) is now required for the Default and DefaultOAuth platform types. Set it, or call the deprecated UseLegacyDomain() to keep using the shared checkout.com hosts (#590)
- An invalid subdomain now throws instead of being silently ignored (#590)
- Add optional amount to VoidRequest to support partial voids (#597)
- Add the ISV (SaaS seller) payout schedule fields balance_minimum, carry_forward_enabled and payment_instrument_id (#593)
- Add the SEPA mandate type field to instrument_data (#598)